### PR TITLE
chore: add .gitignore for node, vite, and editor artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.vite/
+.env.local
+.DS_Store
+*.log


### PR DESCRIPTION
First commit on Day 1 scaffold branch — establishes ignore rules for node_modules, vite build output, local env files, and OS/editor cruft before any tooling lands in the repo.