### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- One or two sentences on what landed. Avoid restating the title. -->
+
+
+## Issues closed
+
+<!-- Use Closes / Fixes / Resolves so GitHub auto-closes the linked issues
+     on merge. One per line, or comma-separated. Remove this section if
+     the PR doesn't close any issue. -->
+
+Closes #
+
+
+## Test plan
+
+<!-- Commands you ran and what you verified. Be specific — "tested locally"
+     doesn't count. Tick the boxes that apply and add manual checks below. -->
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] Manual smoke test (describe what you exercised in the browser):


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` with three sections — Summary, Issues closed (`Closes #N` stubbed), and Test plan — so future PRs auto-populate with the structure recommended in the 2026-05-01 audit. First merge that benefits will be the next non-template PR.

## Issues closed

(none — process improvement, no tracked issue)

## Test plan

Markdown-only change; no code paths touched. Will see the template auto-apply on the next PR opened against `main`.
