### PR TITLE
fix(core): align $sp init value with engine canonical 0x7FFFEFFC

### DIFF
--- a/docs/TASKS_ZACHARY.md
+++ b/docs/TASKS_ZACHARY.md
@@ -34,7 +34,7 @@ snapshot(): RegisterSnapshot   // matches src/hooks/types.ts
 `initialRegisters` in `src/hooks/useSimulator.ts` now sets:
 
 - `pc = 0x00400000` (canonical MIPS text base)
-- `gpr.$sp = 0x7FFFFFFC` (canonical MARS stack-top init)
+- `gpr.$sp = 0x7FFFEFFC` (canonical MARS stack-top init)
 
 (Added in SA-6.5.) Your `reset()` must restore those exact values,
 **not zero**. Import the constants from `src/hooks/useSimulator.ts`
@@ -70,7 +70,7 @@ one shape and stick with it for all instructions.
 ```
 step()   executes 1 instruction; advances PC by 4 unless a branch was taken
 run()    loops step() until halt or breakpoint  (breakpoints are Day 4)
-reset()  restores initialRegisters, clears memory, PC = 0x00400000, $sp = 0x7FFFFFFC
+reset()  restores initialRegisters, clears memory, PC = 0x00400000, $sp = 0x7FFFEFFC
 ```
 
 ## Day 3 — Thursday Apr 30

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -10,14 +10,14 @@ import type {
   SimStatus,
 } from './types.ts'
 
-// Canonical MIPS conventions: program text starts at 0x00400000 and
-// the stack pointer initializes near the top of the user data segment
-// at 0x7FFFFFFC (the highest 4-byte-aligned address in the stack).
-// Real MARS sets these on reset; matching it here keeps cross-checks
-// against MARS exact and gives Zachary's reset() a single source of
-// truth to import from.
+// Canonical MIPS / real-MARS conventions: program text starts at
+// 0x00400000 and the stack pointer initializes at 0x7FFFEFFC (top of
+// the user stack segment, just below the kernel-reserved region). The
+// engine's createRegisterFile() in src/core/registers.ts uses the same
+// value, so the pre-Assemble register table and the post-Assemble
+// snapshot agree on $sp without a visible value jump.
 const MIPS_TEXT_BASE = 0x00400000
-const MIPS_STACK_TOP = 0x7ffffffc
+const MIPS_STACK_TOP = 0x7fffeffc
 
 // Pre-loaded so the editor never reads as a wireframe on first paint
 // and so screenshots of WebMARS show working code, not an empty pane.


### PR DESCRIPTION
## Summary

Aligns the store's `MIPS_STACK_TOP` constant with the engine's `createRegisterFile()` value (`0x7FFFEFFC`). Resolves the visible `$sp` jump from `0x7FFFFFFC` → `0x7FFFEFFC` that occurred when the user clicked Assemble (the symptom in #15). Also corrects two stale value references in `docs/TASKS_ZACHARY.md` and rewrites the explanatory comment in `useSimulator.ts` to document why the two sides must agree.

## Issues closed

Closes #15

## Test plan

- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — exit 0
- [x] `npm run build` — exit 0
- [ ] `npm test` — N/A; constant-only change, no test added
- [x] Manual smoke check: `grep -rni "0x7FFFFFFC" src/ docs/` returns 0 hits; `grep -rni "0x7FFFEFFC"` returns 5 hits across `src/hooks/useSimulator.ts` (×2: comment + constant) and `docs/TASKS_ZACHARY.md` (×3: lines 37, 54, 73 — line 54 was already correct, the others now match it).

The Day 1 plan doc (`WebMARS_Day1_Bryan.docx`, not in the repo) used the old `0x7FFFFFFC` value — historical artifact of how the audit surfaced the drift. Not modified.
