### PR TITLE
feat: phase 2b–h — fpu, delay slots, smc guard, traps, syscalls

### DIFF
--- a/src/core/instructions.ts
+++ b/src/core/instructions.ts
@@ -495,6 +495,17 @@ export function assemble(source: string): AssembledProgram {
           }
           case 'nop': instr = 0; consumed = 0; break;
 
+          // ─ Phase 2F — trap instructions ─
+          // Two-operand R-type: teq $rs, $rt → rType(0, rs=getR(0),
+          // rt=getR(2), rd=0, shamt=0, funct=0x34). Code in bits
+          // 15:6 (rd+shamt) is unused — set to 0.
+          case 'teq':  instr = rType(0, getR(0), getR(2), 0, 0, 0x34); consumed = 3; break;
+          case 'tne':  instr = rType(0, getR(0), getR(2), 0, 0, 0x36); consumed = 3; break;
+          case 'tlt':  instr = rType(0, getR(0), getR(2), 0, 0, 0x32); consumed = 3; break;
+          case 'tltu': instr = rType(0, getR(0), getR(2), 0, 0, 0x33); consumed = 3; break;
+          case 'tge':  instr = rType(0, getR(0), getR(2), 0, 0, 0x30); consumed = 3; break;
+          case 'tgeu': instr = rType(0, getR(0), getR(2), 0, 0, 0x31); consumed = 3; break;
+
           // ─ Coprocessor 1 (FPU) ─
           // The FPU encoding reuses the rType field layout: cop1 op
           // 0x11, with rs slot = fmt (0x10 for .s, 0x14 for .w),

--- a/src/core/instructions.ts
+++ b/src/core/instructions.ts
@@ -494,6 +494,80 @@ export function assemble(source: string): AssembledProgram {
             consumed = 3; break;
           }
           case 'nop': instr = 0; consumed = 0; break;
+
+          // ─ Coprocessor 1 (FPU) ─
+          // The FPU encoding reuses the rType field layout: cop1 op
+          // 0x11, with rs slot = fmt (0x10 for .s, 0x14 for .w),
+          // rt slot = ft, rd slot = fs, shamt slot = fd. So the
+          // assembler positions are: getR(0)→fd, getR(2)→fs,
+          // getR(4)→ft, mirroring how the decoder unpacks them.
+
+          // 3-operand single-precision: op.s $fd, $fs, $ft
+          case 'add.s': instr = rType(0x11, 0x10, getR(4), getR(2), getR(0), 0x00); consumed = 5; break;
+          case 'sub.s': instr = rType(0x11, 0x10, getR(4), getR(2), getR(0), 0x01); consumed = 5; break;
+          case 'mul.s': instr = rType(0x11, 0x10, getR(4), getR(2), getR(0), 0x02); consumed = 5; break;
+          case 'div.s': instr = rType(0x11, 0x10, getR(4), getR(2), getR(0), 0x03); consumed = 5; break;
+
+          // 2-operand single-precision: op.s $fd, $fs (ft slot unused, must be 0)
+          case 'sqrt.s': instr = rType(0x11, 0x10, 0, getR(2), getR(0), 0x04); consumed = 3; break;
+          case 'abs.s':  instr = rType(0x11, 0x10, 0, getR(2), getR(0), 0x05); consumed = 3; break;
+          case 'mov.s':  instr = rType(0x11, 0x10, 0, getR(2), getR(0), 0x06); consumed = 3; break;
+          case 'neg.s':  instr = rType(0x11, 0x10, 0, getR(2), getR(0), 0x07); consumed = 3; break;
+
+          // Conversions — fmt names the SOURCE format. cvt.<dst>.<src>
+          case 'cvt.w.s': instr = rType(0x11, 0x10, 0, getR(2), getR(0), 0x24); consumed = 3; break;
+          case 'cvt.s.w': instr = rType(0x11, 0x14, 0, getR(2), getR(0), 0x20); consumed = 3; break;
+
+          // Compare single-precision: c.cond.s $fs, $ft (sets cc[0]; no fd)
+          case 'c.eq.s': instr = rType(0x11, 0x10, getR(2), getR(0), 0, 0x32); consumed = 3; break;
+          case 'c.lt.s': instr = rType(0x11, 0x10, getR(2), getR(0), 0, 0x3c); consumed = 3; break;
+          case 'c.le.s': instr = rType(0x11, 0x10, getR(2), getR(0), 0, 0x3e); consumed = 3; break;
+
+          // Branch on FP condition flag — sub-op fmt = 0x08; rt = 0
+          // for bc1f (false), 1 for bc1t (true). Branch offset is
+          // computed the same way as integer branches.
+          case 'bc1f': {
+            const labelTok = nextToks[0];
+            const off = labelTok?.type === 'ident' ? getBranchOffset(labelTok.value) : getI(0);
+            instr = iType(0x11, 0x08, 0x00, off); consumed = 1; break;
+          }
+          case 'bc1t': {
+            const labelTok = nextToks[0];
+            const off = labelTok?.type === 'ident' ? getBranchOffset(labelTok.value) : getI(0);
+            instr = iType(0x11, 0x08, 0x01, off); consumed = 1; break;
+          }
+
+          // Move between GPR and FPR. mfc1/mtc1 use the rt field for
+          // the GPR and the fs (rd) field for the FPR.
+          case 'mfc1': instr = rType(0x11, 0x00, getR(0), getR(2), 0, 0x00); consumed = 3; break;
+          case 'mtc1': instr = rType(0x11, 0x04, getR(0), getR(2), 0, 0x00); consumed = 3; break;
+
+          // FP load/store — accept both "lwc1 $ft, off($rs)" and
+          // the imm + base flat form, mirroring the integer lw/sw
+          // parsing convention above.
+          case 'lwc1': {
+            const rt2 = getR(0)
+            const immTok = nextToks[2]
+            let base: number, offset: number
+            if (immTok?.type === 'immediate' && nextToks[3]?.type === 'lparen') {
+              offset = parseImm(immTok.value)
+              base = getReg(nextToks[4], errors)
+              consumed = 6
+            } else { offset = getI(2); base = getR(4); consumed = 5 }
+            instr = iType(0x31, base, rt2, offset); break
+          }
+          case 'swc1': {
+            const rt2 = getR(0)
+            const immTok = nextToks[2]
+            let base: number, offset: number
+            if (immTok?.type === 'immediate' && nextToks[3]?.type === 'lparen') {
+              offset = parseImm(immTok.value)
+              base = getReg(nextToks[4], errors)
+              consumed = 6
+            } else { offset = getI(2); base = getR(4); consumed = 5 }
+            instr = iType(0x39, base, rt2, offset); break
+          }
+
           default:
             errors.push({ line, message: `Unknown mnemonic: ${mnemonic}` });
         }

--- a/src/core/memory.ts
+++ b/src/core/memory.ts
@@ -8,10 +8,20 @@ export const MEM_SIZE   = 0x00800000;
 export class Memory {
   private buf: ArrayBuffer;
   private view: DataView;
+  // Phase 2D — when false (default), stores to addresses in the
+  // .text segment throw. Real MARS rejects self-modifying code by
+  // default; flipping this on lets advanced examples patch the
+  // instruction stream at runtime. Program-loader writes go through
+  // loadProgram() which bypasses the guard.
+  private allowTextWrites: boolean = false;
 
   constructor() {
     this.buf = new ArrayBuffer(MEM_SIZE);
     this.view = new DataView(this.buf);
+  }
+
+  setAllowTextWrites(on: boolean): void {
+    this.allowTextWrites = on;
   }
 
   private offset(addr: number): number {
@@ -22,6 +32,17 @@ export class Memory {
     throw new Error(`Memory access out of range: 0x${a.toString(16)}`);
   }
 
+  private guardWrite(addr: number): void {
+    const a = toUnsigned32(addr);
+    if (this.allowTextWrites) return;
+    if (a >= TEXT_BASE && a < TEXT_BASE + 0x00100000) {
+      throw new Error(
+        `Self-modifying code: store to .text at 0x${a.toString(16)}. ` +
+        `Enable Settings → Simulator → "Self-modifying code allowed" to permit.`,
+      );
+    }
+  }
+
   readWord(addr: number): number {
     if (addr & 3) throw new Error(`Unaligned word read at 0x${toUnsigned32(addr).toString(16)}`);
     return this.view.getInt32(this.offset(addr), false);
@@ -29,6 +50,7 @@ export class Memory {
 
   writeWord(addr: number, val: number): void {
     if (addr & 3) throw new Error(`Unaligned word write at 0x${toUnsigned32(addr).toString(16)}`);
+    this.guardWrite(addr);
     this.view.setInt32(this.offset(addr), val, false);
   }
 
@@ -39,6 +61,7 @@ export class Memory {
 
   writeHalf(addr: number, val: number): void {
     if (addr & 1) throw new Error(`Unaligned halfword write`);
+    this.guardWrite(addr);
     this.view.setInt16(this.offset(addr), val & 0xffff, false);
   }
 
@@ -47,6 +70,7 @@ export class Memory {
   }
 
   writeByte(addr: number, val: number): void {
+    this.guardWrite(addr);
     this.view.setInt8(this.offset(addr), val & 0xff);
   }
 

--- a/src/core/registers.ts
+++ b/src/core/registers.ts
@@ -11,6 +11,12 @@ export const REGISTER_NAMES: string[] = [
 export const REGISTER_INDEX: Record<string, number> = {};
 REGISTER_NAMES.forEach((name, i) => { REGISTER_INDEX[name] = i; });
 for (let i = 0; i < 32; i++) { REGISTER_INDEX[`$${i}`] = i; }
+// FPU register names share the index space with the GPR set — both
+// $zero and $f0 map to 0. The assembler dispatches on mnemonic, not
+// register family, so reusing the index is harmless: a "$f0" token
+// reaching the GPR-typed `add` opcode would just encode wrong, but
+// the same is true of using "$zero" with FPU opcodes today.
+for (let i = 0; i < 32; i++) { REGISTER_INDEX[`$f${i}`] = i; }
 
 export function createRegisterFile(): number[] {
   const regs = new Array<number>(32).fill(0);
@@ -27,4 +33,45 @@ export function toSigned32(n: number): number {
 
 export function toUnsigned32(n: number): number {
   return (n >>> 0);
+}
+
+// ─ FPU (coprocessor 1) ─────────────────────────────────────────────
+//
+// MIPS32 FPU exposes 32 single-precision registers $f0..$f31. Each is
+// stored here as a raw 32-bit word; the .s and .w instructions
+// reinterpret those bits as float32 / int32 on demand. Real MIPS32
+// pairs adjacent slots for double-precision (e.g. $f0:$f1 holds a
+// double); double-precision support is deferred — Phase 2B ships
+// single-precision plus the integer ↔ single conversion ops.
+
+export const FPU_REGISTER_NAMES: string[] = Array.from(
+  { length: 32 },
+  (_, i) => `$f${i}`,
+)
+
+export function createFpuRegisterFile(): number[] {
+  return new Array<number>(32).fill(0)
+}
+
+// Reinterpret-cast helpers — JS doesn't have a native union type for
+// f32/i32 bits, so go through a 4-byte ArrayBuffer view. The buffer
+// is module-local, single-element, and reused per call.
+const _convBuf  = new ArrayBuffer(4)
+const _convI32  = new Int32Array(_convBuf)
+const _convU32  = new Uint32Array(_convBuf)
+const _convF32  = new Float32Array(_convBuf)
+
+export function bitsToFloat(bits: number): number {
+  _convI32[0] = bits | 0
+  return _convF32[0] ?? 0
+}
+
+export function floatToBits(value: number): number {
+  _convF32[0] = value
+  return _convI32[0] ?? 0
+}
+
+export function bitsToUnsignedFloat(bits: number): number {
+  _convU32[0] = bits >>> 0
+  return _convF32[0] ?? 0
 }

--- a/src/core/simulator.ts
+++ b/src/core/simulator.ts
@@ -327,12 +327,22 @@ export class Simulator {
     } else {
       switch (op) {
         case 0x08: this.setReg(rt, this.r(rs) + imm16s); break
-        case 0x09: this.setReg(rt, toUnsigned32(this.r(rs)) + imm16u); break
+        // ADDIU sign-extends the immediate per the MIPS spec (the
+        // "U" only means "no overflow trap"). Earlier engine builds
+        // used imm16u here, which silently corrupted any program
+        // that did `addiu $t, $t, -N` or `li $t, -N` (the latter
+        // expands to addiu when |N| < 32768).
+        case 0x09: this.setReg(rt, this.r(rs) + imm16s); break
         case 0x0c: this.setReg(rt, this.r(rs) & imm16u); break
         case 0x0d: this.setReg(rt, this.r(rs) | imm16u); break
         case 0x0e: this.setReg(rt, this.r(rs) ^ imm16u); break
         case 0x0a: this.setReg(rt, toSigned32(this.r(rs)) < imm16s ? 1 : 0); break
-        case 0x0b: this.setReg(rt, toUnsigned32(this.r(rs)) < imm16u ? 1 : 0); break
+        // SLTIU sign-extends the immediate to 32 bits, then compares
+        // both operands as unsigned integers. The previous code used
+        // imm16u (zero-extended) which made `sltiu $t, $rs, -1` flag
+        // the wrong direction — comparing against 0xffff instead of
+        // 0xffffffff.
+        case 0x0b: this.setReg(rt, toUnsigned32(this.r(rs)) < toUnsigned32(imm16s) ? 1 : 0); break
         case 0x0f: this.setReg(rt, imm16u << 16); break
         case 0x23: this.setReg(rt, this.memory.readWord(this.r(rs) + imm16s)); break
         case 0x21: this.setReg(rt, this.memory.readHalf(this.r(rs) + imm16s)); break

--- a/src/core/simulator.ts
+++ b/src/core/simulator.ts
@@ -67,6 +67,10 @@ export class Simulator {
     if (!on) this.pendingBranchTarget = null
   }
 
+  setAllowSelfModifyingCode(on: boolean): void {
+    this.memory.setAllowTextWrites(on)
+  }
+
   // Branch/jump dispatch. Called from execute(); routes through
   // pendingBranchTarget when delayed branching is on so the next
   // step()'s instruction (the delay slot) runs before the target

--- a/src/core/simulator.ts
+++ b/src/core/simulator.ts
@@ -1,4 +1,11 @@
-import { createRegisterFile, toSigned32, toUnsigned32 } from './registers'
+import {
+  createRegisterFile,
+  createFpuRegisterFile,
+  bitsToFloat,
+  floatToBits,
+  toSigned32,
+  toUnsigned32,
+} from './registers'
 import { Memory, TEXT_BASE } from './memory'
 import { handleSyscall, type SyscallIO } from './syscalls'
 import type { AssembledProgram } from './types'
@@ -13,22 +20,31 @@ export class Simulator {
   private halted: boolean = false
   private stepCount: number = 0
   private lastChanged: Set<number> = new Set()
+  // ─ coprocessor 1 (FPU) ─
+  // Single-precision register bits + the FCSR cc[0] bit set by c.cond.s.
+  private fpRegs: number[]
+  private fpCondFlag: boolean = false
+  private lastChangedFp: Set<number> = new Set()
   private io: SyscallIO
 
   constructor(io: SyscallIO) {
     this.regs = createRegisterFile()
+    this.fpRegs = createFpuRegisterFile()
     this.memory = new Memory()
     this.io = io
   }
 
   load(program: AssembledProgram): void {
     this.regs = createRegisterFile()
+    this.fpRegs = createFpuRegisterFile()
+    this.fpCondFlag = false
     this.hi = 0
     this.lo = 0
     this.pc = TEXT_BASE
     this.halted = false
     this.stepCount = 0
     this.lastChanged = new Set()
+    this.lastChangedFp = new Set()
     this.memory = new Memory()
     this.memory.loadProgram(program.instructions, program.dataSegment)
     this.program = program
@@ -49,6 +65,38 @@ export class Simulator {
     }
   }
 
+  // FPU snapshot — separate from getState() so the existing contract
+  // (RegisterSnapshot) doesn't expand. The store reads this only when
+  // the FPU panel is mounted (gated by simSettings.coproc01Panels).
+  getFpuState(): { fpRegisters: number[]; condFlag: boolean; lastChangedFpRegisters: Set<number> } {
+    return {
+      fpRegisters: [...this.fpRegs],
+      condFlag: this.fpCondFlag,
+      lastChangedFpRegisters: new Set(this.lastChangedFp),
+    }
+  }
+
+  // Reinterpret-cast helpers used by the cop1 instruction decoder.
+  // Setting an FP register clears the lastChanged GPR set so the
+  // register table flash works for FPU writes too.
+  private fr(idx: number): number {
+    return this.fpRegs[idx] ?? 0
+  }
+
+  private setFpReg(idx: number, bits: number): void {
+    if (idx < 0 || idx > 31) return
+    this.fpRegs[idx] = bits | 0
+    this.lastChangedFp.add(idx)
+  }
+
+  private fpSingle(idx: number): number {
+    return bitsToFloat(this.fr(idx))
+  }
+
+  private setFpSingle(idx: number, value: number): void {
+    this.setFpReg(idx, floatToBits(value))
+  }
+
   getCurrentLine(): number | null {
     return this.program?.sourceMap.get(this.pc) ?? null
   }
@@ -64,6 +112,7 @@ export class Simulator {
   async step(): Promise<void> {
     if (this.halted) return
     this.lastChanged = new Set()
+    this.lastChangedFp = new Set()
     const instr = this.memory.readWord(this.pc)
     this.pc += 4
     await this.execute(instr)
@@ -165,6 +214,57 @@ export class Simulator {
     } else if (op === 0x03) {
       this.setReg(31, this.pc)
       this.pc = ((this.pc & 0xf0000000) | (target << 2))
+    } else if (op === 0x11) {
+      // ─ coprocessor 1 (FPU) ─
+      // Layout: bits 25:21 = fmt (or sub-op for mtc1/mfc1/bc1),
+      // 20:16 = ft, 15:11 = fs, 10:6 = fd, 5:0 = funct.
+      const fmt = (instr >>> 21) & 0x1f
+      const ft  = (instr >>> 16) & 0x1f
+      const fs  = (instr >>> 11) & 0x1f
+      const fd  = (instr >>> 6)  & 0x1f
+      // bc1 uses imm16s (relative branch in instruction-count units).
+      if (fmt === 0x08) {
+        // BC1F (rt&1==0) / BC1T (rt&1==1). Real MIPS encodes the
+        // condition code in bits 20:18; we only support cc=0.
+        const takeIfTrue = (ft & 0x01) === 1
+        const taken = takeIfTrue ? this.fpCondFlag : !this.fpCondFlag
+        if (taken) this.pc += imm16s * 4 - 4
+      } else if (fmt === 0x00) {
+        // MFC1 — move FP word to GPR. rt = bits of fs as a sign-
+        // extended 32-bit integer.
+        this.setReg(ft, toSigned32(this.fr(fs)))
+      } else if (fmt === 0x04) {
+        // MTC1 — move GPR word to FP. fs ← bits(rt).
+        this.setFpReg(fs, this.r(ft))
+      } else if (fmt === 0x10) {
+        // FMT_S — single-precision arithmetic + comparison.
+        switch (funct) {
+          case 0x00: this.setFpSingle(fd, this.fpSingle(fs) + this.fpSingle(ft)); break  // add.s
+          case 0x01: this.setFpSingle(fd, this.fpSingle(fs) - this.fpSingle(ft)); break  // sub.s
+          case 0x02: this.setFpSingle(fd, this.fpSingle(fs) * this.fpSingle(ft)); break  // mul.s
+          case 0x03: this.setFpSingle(fd, this.fpSingle(fs) / this.fpSingle(ft)); break  // div.s
+          case 0x04: this.setFpSingle(fd, Math.sqrt(this.fpSingle(fs))); break             // sqrt.s
+          case 0x05: this.setFpSingle(fd, Math.abs(this.fpSingle(fs))); break              // abs.s
+          case 0x06: this.setFpReg(fd, this.fr(fs)); break                                  // mov.s
+          case 0x07: this.setFpSingle(fd, -this.fpSingle(fs)); break                        // neg.s
+          case 0x24: this.setFpReg(fd, toSigned32(Math.trunc(this.fpSingle(fs)))); break    // cvt.w.s
+          case 0x32: this.fpCondFlag = this.fpSingle(fs) === this.fpSingle(ft); break       // c.eq.s
+          case 0x3c: this.fpCondFlag = this.fpSingle(fs) <  this.fpSingle(ft); break        // c.lt.s
+          case 0x3e: this.fpCondFlag = this.fpSingle(fs) <= this.fpSingle(ft); break        // c.le.s
+          default:
+            throw new Error(`Unknown cop1 fmt.s funct: 0x${funct.toString(16)}`)
+        }
+      } else if (fmt === 0x14) {
+        // FMT_W — integer-formatted FP register. Only conversion to
+        // single-precision is supported (cvt.s.w).
+        switch (funct) {
+          case 0x20: this.setFpSingle(fd, toSigned32(this.fr(fs))); break  // cvt.s.w
+          default:
+            throw new Error(`Unknown cop1 fmt.w funct: 0x${funct.toString(16)}`)
+        }
+      } else {
+        throw new Error(`Unknown cop1 fmt: 0x${fmt.toString(16)}`)
+      }
     } else {
       switch (op) {
         case 0x08: this.setReg(rt, this.r(rs) + imm16s); break
@@ -183,6 +283,8 @@ export class Simulator {
         case 0x2b: this.memory.writeWord(this.r(rs) + imm16s, this.r(rt)); break
         case 0x29: this.memory.writeHalf(this.r(rs) + imm16s, this.r(rt)); break
         case 0x28: this.memory.writeByte(this.r(rs) + imm16s, this.r(rt)); break
+        case 0x31: this.setFpReg(rt, this.memory.readWord(this.r(rs) + imm16s)); break    // lwc1 — fpr[rt] = MEM[rs+off]
+        case 0x39: this.memory.writeWord(this.r(rs) + imm16s, this.fr(rt)); break          // swc1 — MEM[rs+off] = fpr[rt]
         case 0x04: if (this.r(rs) === this.r(rt)) this.pc += imm16s * 4 - 4; break
         case 0x05: if (this.r(rs) !== this.r(rt)) this.pc += imm16s * 4 - 4; break
         case 0x07: if (toSigned32(this.r(rs)) > 0) this.pc += imm16s * 4 - 4; break

--- a/src/core/simulator.ts
+++ b/src/core/simulator.ts
@@ -25,6 +25,14 @@ export class Simulator {
   private fpRegs: number[]
   private fpCondFlag: boolean = false
   private lastChangedFp: Set<number> = new Set()
+  // ─ delayed branching (Phase 2C) ─
+  // When on, branch / jump targets aren't applied immediately —
+  // they're queued in pendingBranchTarget and committed at the end
+  // of the FOLLOWING step, so the delay slot instruction executes
+  // first (real MIPS semantics). Off by default — most courses
+  // teach without delay slots and the existing examples assume that.
+  private delayedBranching: boolean = false
+  private pendingBranchTarget: number | null = null
   private io: SyscallIO
 
   constructor(io: SyscallIO) {
@@ -45,9 +53,28 @@ export class Simulator {
     this.stepCount = 0
     this.lastChanged = new Set()
     this.lastChangedFp = new Set()
+    this.pendingBranchTarget = null
     this.memory = new Memory()
     this.memory.loadProgram(program.instructions, program.dataSegment)
     this.program = program
+  }
+
+  setDelayedBranching(on: boolean): void {
+    this.delayedBranching = on
+    // Discard any in-flight pending branch when the flag flips —
+    // mid-program toggles otherwise leave a stale target queued
+    // against semantics the user just opted out of.
+    if (!on) this.pendingBranchTarget = null
+  }
+
+  // Branch/jump dispatch. Called from execute(); routes through
+  // pendingBranchTarget when delayed branching is on so the next
+  // step()'s instruction (the delay slot) runs before the target
+  // is applied.
+  private setBranchTarget(target: number): void {
+    const t = target >>> 0
+    if (this.delayedBranching) this.pendingBranchTarget = t
+    else this.pc = t
   }
 
   reset(): void {
@@ -113,9 +140,24 @@ export class Simulator {
     if (this.halted) return
     this.lastChanged = new Set()
     this.lastChangedFp = new Set()
+
+    // Snapshot the pending branch BEFORE execute. If a branch fired
+    // last step, this step's instruction is its delay slot — execute
+    // first, then commit the target. Done in this order so that
+    // arithmetic / memory side-effects of the delay slot land before
+    // the PC jumps; if the delay slot is itself a branch, its target
+    // overwrites pendingBranchTarget for the NEXT cycle.
+    const pendingFromPriorStep = this.pendingBranchTarget
+    this.pendingBranchTarget = null
+
     const instr = this.memory.readWord(this.pc)
     this.pc += 4
     await this.execute(instr)
+
+    if (pendingFromPriorStep !== null) {
+      this.pc = pendingFromPriorStep
+    }
+
     this.stepCount++
     this.regs[0] = 0
   }
@@ -195,10 +237,13 @@ export class Simulator {
         case 0x12: this.setReg(rd, this.lo); break
         case 0x11: this.hi = this.r(rs); break
         case 0x13: this.lo = this.r(rs); break
-        case 0x08: this.pc = toUnsigned32(this.r(rs)); break
+        case 0x08: this.setBranchTarget(toUnsigned32(this.r(rs))); break
         case 0x09:
-          this.setReg(rd === 0 ? 31 : rd, this.pc)
-          this.pc = toUnsigned32(this.r(rs))
+          // jalr — link register holds the return address. With
+          // delayed branching on, the delay slot will execute next,
+          // so $ra should point past it (PC+4 of the caller frame).
+          this.setReg(rd === 0 ? 31 : rd, this.delayedBranching ? this.pc + 4 : this.pc)
+          this.setBranchTarget(toUnsigned32(this.r(rs)))
           break
         case 0x0c: {
           const syscallCode = this.r(2)
@@ -210,10 +255,10 @@ export class Simulator {
           throw new Error(`Unknown R-type funct: 0x${funct.toString(16)}`)
       }
     } else if (op === 0x02) {
-      this.pc = ((this.pc & 0xf0000000) | (target << 2))
+      this.setBranchTarget((this.pc & 0xf0000000) | (target << 2))
     } else if (op === 0x03) {
-      this.setReg(31, this.pc)
-      this.pc = ((this.pc & 0xf0000000) | (target << 2))
+      this.setReg(31, this.delayedBranching ? this.pc + 4 : this.pc)
+      this.setBranchTarget((this.pc & 0xf0000000) | (target << 2))
     } else if (op === 0x11) {
       // ─ coprocessor 1 (FPU) ─
       // Layout: bits 25:21 = fmt (or sub-op for mtc1/mfc1/bc1),
@@ -228,7 +273,7 @@ export class Simulator {
         // condition code in bits 20:18; we only support cc=0.
         const takeIfTrue = (ft & 0x01) === 1
         const taken = takeIfTrue ? this.fpCondFlag : !this.fpCondFlag
-        if (taken) this.pc += imm16s * 4 - 4
+        if (taken) this.setBranchTarget(this.pc + imm16s * 4 - 4)
       } else if (fmt === 0x00) {
         // MFC1 — move FP word to GPR. rt = bits of fs as a sign-
         // extended 32-bit integer.
@@ -285,13 +330,13 @@ export class Simulator {
         case 0x28: this.memory.writeByte(this.r(rs) + imm16s, this.r(rt)); break
         case 0x31: this.setFpReg(rt, this.memory.readWord(this.r(rs) + imm16s)); break    // lwc1 — fpr[rt] = MEM[rs+off]
         case 0x39: this.memory.writeWord(this.r(rs) + imm16s, this.fr(rt)); break          // swc1 — MEM[rs+off] = fpr[rt]
-        case 0x04: if (this.r(rs) === this.r(rt)) this.pc += imm16s * 4 - 4; break
-        case 0x05: if (this.r(rs) !== this.r(rt)) this.pc += imm16s * 4 - 4; break
-        case 0x07: if (toSigned32(this.r(rs)) > 0) this.pc += imm16s * 4 - 4; break
-        case 0x06: if (toSigned32(this.r(rs)) <= 0) this.pc += imm16s * 4 - 4; break
+        case 0x04: if (this.r(rs) === this.r(rt))      this.setBranchTarget(this.pc + imm16s * 4 - 4); break
+        case 0x05: if (this.r(rs) !== this.r(rt))      this.setBranchTarget(this.pc + imm16s * 4 - 4); break
+        case 0x07: if (toSigned32(this.r(rs)) >  0)    this.setBranchTarget(this.pc + imm16s * 4 - 4); break
+        case 0x06: if (toSigned32(this.r(rs)) <= 0)    this.setBranchTarget(this.pc + imm16s * 4 - 4); break
         case 0x01:
-          if (rt === 0 && toSigned32(this.r(rs)) < 0) this.pc += imm16s * 4 - 4
-          if (rt === 1 && toSigned32(this.r(rs)) >= 0) this.pc += imm16s * 4 - 4
+          if (rt === 0 && toSigned32(this.r(rs)) <  0) this.setBranchTarget(this.pc + imm16s * 4 - 4)
+          if (rt === 1 && toSigned32(this.r(rs)) >= 0) this.setBranchTarget(this.pc + imm16s * 4 - 4)
           break
         default:
           throw new Error(`Unknown opcode: 0x${op.toString(16)}`)

--- a/src/core/simulator.ts
+++ b/src/core/simulator.ts
@@ -255,6 +255,16 @@ export class Simulator {
           if (syscallCode === 10) this.halted = true
           break
         }
+        // ─ Phase 2F — trap instructions ─
+        // Each fires a runtime trap (modeled as a thrown error) when
+        // its condition holds. The message names the mnemonic + the
+        // operand values so the runtime panel can show what tripped.
+        case 0x30: if (toSigned32(this.r(rs)) >= toSigned32(this.r(rt))) throw new Error(`Trap: tge ($${rs}=${this.r(rs)}) >= ($${rt}=${this.r(rt)})`); break
+        case 0x31: if (toUnsigned32(this.r(rs)) >= toUnsigned32(this.r(rt))) throw new Error(`Trap: tgeu ($${rs}=${this.r(rs) >>> 0}) >= ($${rt}=${this.r(rt) >>> 0})`); break
+        case 0x32: if (toSigned32(this.r(rs)) <  toSigned32(this.r(rt))) throw new Error(`Trap: tlt ($${rs}=${this.r(rs)}) < ($${rt}=${this.r(rt)})`); break
+        case 0x33: if (toUnsigned32(this.r(rs)) <  toUnsigned32(this.r(rt))) throw new Error(`Trap: tltu ($${rs}=${this.r(rs) >>> 0}) < ($${rt}=${this.r(rt) >>> 0})`); break
+        case 0x34: if (this.r(rs) === this.r(rt)) throw new Error(`Trap: teq ($${rs}=${this.r(rs)}) == ($${rt}=${this.r(rt)})`); break
+        case 0x36: if (this.r(rs) !== this.r(rt)) throw new Error(`Trap: tne ($${rs}=${this.r(rs)}) != ($${rt}=${this.r(rt)})`); break
         default:
           throw new Error(`Unknown R-type funct: 0x${funct.toString(16)}`)
       }

--- a/src/core/syscalls.ts
+++ b/src/core/syscalls.ts
@@ -17,6 +17,13 @@ export interface SyscallIO {
   readChar?:    () => Promise<string>
   confirm?:     (message: string) => Promise<0 | 1 | 2>   // Yes / No / Cancel
   alert?:       (message: string, kind: DialogKind) => Promise<void>
+
+  // Phase 2H — input dialog syscalls. The result tuple wraps the
+  // user's value alongside a `cancelled` flag so the engine can
+  // pick the right MARS status code for $a1 (-3 = cancel, -2 =
+  // invalid input, -4 = buffer too small).
+  promptInt?:    (message: string) => Promise<{ value: number; cancelled: boolean; invalid?: boolean }>
+  promptString?: (message: string) => Promise<{ value: string; cancelled: boolean }>
 }
 
 export function handleSyscall(
@@ -109,6 +116,45 @@ export function handleSyscall(
       const msg = readCStr(memory, registers[4] ?? 0)
       return io.confirm(msg).then((result) => {
         registers[4] = result
+      })
+    }
+    case 51: {
+      // input int dialog. $a0 = prompt addr. Returns int in $a0;
+      // $a1 = 0 on success, -2 on invalid input, -3 on cancel.
+      if (!io.promptInt) throw new Error('Syscall 51 (input int dialog) requires an io.promptInt handler')
+      const msg = readCStr(memory, registers[4] ?? 0)
+      return io.promptInt(msg).then((result) => {
+        if (result.cancelled) {
+          registers[4] = 0
+          registers[5] = -3
+        } else if (result.invalid) {
+          registers[4] = 0
+          registers[5] = -2
+        } else {
+          registers[4] = result.value | 0
+          registers[5] = 0
+        }
+      })
+    }
+    case 53: {
+      // input string dialog. $a0 = prompt addr, $a1 = buffer addr,
+      // $a2 = max byte count (incl. NUL). $a1 = 0 on success,
+      // -3 on cancel, -4 if buffer too small (truncated).
+      if (!io.promptString) throw new Error('Syscall 53 (input string dialog) requires an io.promptString handler')
+      const msg = readCStr(memory, registers[4] ?? 0)
+      const bufAddr = registers[5] ?? 0
+      const maxLen  = (registers[6] ?? 0) | 0
+      return io.promptString(msg).then((result) => {
+        if (result.cancelled) {
+          registers[5] = -3
+          return
+        }
+        const encoded = new TextEncoder().encode(result.value)
+        const truncated = encoded.length > maxLen - 1
+        const writeLen = Math.min(encoded.length, Math.max(0, maxLen - 1))
+        for (let i = 0; i < writeLen; i++) memory.writeByte(bufAddr + i, encoded[i] ?? 0)
+        memory.writeByte(bufAddr + writeLen, 0)
+        registers[5] = truncated ? -4 : 0
       })
     }
     case 54: {

--- a/src/core/syscalls.ts
+++ b/src/core/syscalls.ts
@@ -1,10 +1,22 @@
 import type { Memory } from './memory'
 
+// MARS dialog syscall (54) message kinds. The numeric codes match
+// real MARS: 0 = info, 1 = info, 2 = warning, 3 = error. We expose
+// them by name for clarity; the syscall handler maps the integer.
+export type DialogKind = 'info' | 'warn' | 'error' | 'question'
+
 export interface SyscallIO {
   print: (s: string) => void
   readInt: () => Promise<number>
   readString: (maxLen: number) => Promise<string>
   exit: () => void
+
+  // Phase 2E additions — optional so older test fixtures keep
+  // working; handleSyscall throws "Unsupported" if a program
+  // requests a syscall whose IO method isn't wired.
+  readChar?:    () => Promise<string>
+  confirm?:     (message: string) => Promise<0 | 1 | 2>   // Yes / No / Cancel
+  alert?:       (message: string, kind: DialogKind) => Promise<void>
 }
 
 export function handleSyscall(
@@ -46,7 +58,87 @@ export function handleSyscall(
     case 10:
       io.exit()
       break
+
+    // ─ Phase 2E syscalls ─
+
+    case 11: {
+      // print char — codepoint (low 8 bits) in $a0
+      const c = (registers[4] ?? 0) & 0xff
+      io.print(String.fromCharCode(c))
+      break
+    }
+    case 12: {
+      // read char — first char of input goes into $v0 as int
+      if (!io.readChar) throw new Error('Syscall 12 (read char) requires an io.readChar handler')
+      return io.readChar().then((s) => {
+        registers[2] = s.length > 0 ? s.charCodeAt(0) : 0
+      })
+    }
+    case 30: {
+      // system time — low 32 bits → $a0, high 32 bits → $a1
+      const now = Date.now()
+      registers[4] = (now & 0xffffffff) | 0
+      registers[5] = Math.floor(now / 0x100000000) | 0
+      break
+    }
+    case 32: {
+      // sleep — millisecond duration in $a0. Returns once the sleep
+      // resolves; the simulator's caller awaits the Promise so the
+      // run loop pauses for real wall time.
+      const ms = (registers[4] ?? 0) | 0
+      return new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, ms)))
+    }
+    case 41: {
+      // random int (no range) — uniform 32-bit int in $a0. JS's
+      // Math.random returns [0,1); scale to int32.
+      registers[4] = Math.floor(Math.random() * 0x100000000) | 0
+      break
+    }
+    case 42: {
+      // random int with range — $a0 = id (ignored, real MARS uses
+      // multi-stream RNG), $a1 = upper bound (exclusive). Result in
+      // $a0 as 0..bound-1.
+      const bound = (registers[5] ?? 0) | 0
+      registers[4] = bound > 0 ? Math.floor(Math.random() * bound) | 0 : 0
+      break
+    }
+    case 50: {
+      // confirm dialog — prompt addr in $a0, response in $a0:
+      // 0 = Yes, 1 = No, 2 = Cancel.
+      if (!io.confirm) throw new Error('Syscall 50 (confirm dialog) requires an io.confirm handler')
+      const msg = readCStr(memory, registers[4] ?? 0)
+      return io.confirm(msg).then((result) => {
+        registers[4] = result
+      })
+    }
+    case 54: {
+      // message dialog — prompt addr in $a0, message-kind code in
+      // $a1 (0/1 = info, 2 = warning, 3 = error).
+      if (!io.alert) throw new Error('Syscall 54 (message dialog) requires an io.alert handler')
+      const msg = readCStr(memory, registers[4] ?? 0)
+      const code = (registers[5] ?? 0) | 0
+      const kind: DialogKind =
+        code === 2 ? 'warn'
+        : code === 3 ? 'error'
+        : code === 4 ? 'question'
+        : 'info'
+      return io.alert(msg, kind)
+    }
+
     default:
       throw new Error(`Unsupported syscall code: ${code}`)
   }
+}
+
+// Read a NUL-terminated ASCII string from memory. Used by syscalls
+// 4 (print string), 50 (confirm), 54 (alert). Capped at 10k bytes
+// to bound runaway reads on uninitialized memory.
+function readCStr(memory: Memory, addr: number): string {
+  let s = ''
+  for (let i = 0; i < 10000; i++) {
+    const b = memory.readUnsignedByte(addr + i)
+    if (b === 0) break
+    s += String.fromCharCode(b)
+  }
+  return s
 }

--- a/src/examples/floatMath.asm
+++ b/src/examples/floatMath.asm
@@ -1,0 +1,35 @@
+# Phase 2B FPU example.
+# Computes sqrt(a*a + b*b) and prints the integer-truncated result.
+
+.data
+a_int:  .word 3
+b_int:  .word 4
+
+.text
+main:
+        # Load the two integers into GPRs.
+        la      $t0, a_int
+        lw      $t1, 0($t0)
+        la      $t0, b_int
+        lw      $t2, 0($t0)
+
+        # Move them across to the FPU and convert to single-precision.
+        mtc1    $t1, $f0
+        cvt.s.w $f0, $f0
+        mtc1    $t2, $f1
+        cvt.s.w $f1, $f1
+
+        # squared = a*a + b*b
+        mul.s   $f2, $f0, $f0
+        mul.s   $f3, $f1, $f1
+        add.s   $f4, $f2, $f3
+
+        # sqrt + truncate to int32; print via syscall 1.
+        sqrt.s  $f5, $f4
+        cvt.w.s $f6, $f5
+        mfc1    $a0, $f6
+        li      $v0, 1
+        syscall
+
+        li      $v0, 10
+        syscall

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -626,6 +626,17 @@ interface SimulatorStoreState {
   toolsDialog: 'instructionCounter' | null
   openTool:  (which: 'instructionCounter') => void
   closeTool: () => void
+
+  // ─ FPU snapshot slice (Phase 2B; not persisted) ─
+  // Mirrors Simulator.getFpuState(). The 32-element values array
+  // holds raw 32-bit words; consumers reinterpret as float32 via
+  // bitsToFloat() from src/core/registers.ts. fpChanged drives the
+  // flash animation, mirroring the GPR snapshot's changed Set.
+  fpRegisters: {
+    values: number[]
+    condFlag: boolean
+    changed: ReadonlySet<number>
+  }
 }
 
 let _sim: Simulator | null = null
@@ -1059,6 +1070,12 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
     openTool:  (which) => set({ toolsDialog: which }),
     closeTool: ()      => set({ toolsDialog: null  }),
 
+    fpRegisters: {
+      values: new Array<number>(32).fill(0),
+      condFlag: false,
+      changed: new Set<number>(),
+    },
+
     writeMemoryWord: (addr, value) => {
       if (!_sim) return false
       const aligned = (addr & ~0x3) >>> 0
@@ -1331,6 +1348,7 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
       sim.load(program)
       patchMemoryForBackstep(sim)
       const engineState = sim.getState()
+      const fpuState = sim.getFpuState()
       set({
         status: 'ready',
         program,
@@ -1339,6 +1357,11 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
         assemblerErrors: [],
         runtimeError: null,
         instructionsExecuted: 0,
+        fpRegisters: {
+          values: fpuState.fpRegisters,
+          condFlag: fpuState.condFlag,
+          changed: fpuState.lastChangedFpRegisters,
+        },
       })
       get().logMessage('info', `Assembled successfully: ${program.instructions.length} instructions.`)
       get().refreshMemorySnapshot()
@@ -1356,10 +1379,16 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
           await sim.step()
           _currentMemWrites = null
           const engineState = sim.getState()
+          const fpuState = sim.getFpuState()
           set({
             status: sim.isHalted() ? 'halted' : 'paused',
             registers: buildSnapshot(engineState, prevRegisters),
             instructionsExecuted: engineState.stepCount,
+            fpRegisters: {
+              values: fpuState.fpRegisters,
+              condFlag: fpuState.condFlag,
+              changed: fpuState.lastChangedFpRegisters,
+            },
           })
           get().refreshMemorySnapshot()
         } catch (e: unknown) {
@@ -1429,6 +1458,7 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
             }
           }
           const engineState = sim.getState()
+          const fpuState = sim.getFpuState()
           const prevRegisters = get().registers
           set({
             status:
@@ -1437,6 +1467,11 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
               : 'paused',
             registers: buildSnapshot(engineState, prevRegisters),
             instructionsExecuted: engineState.stepCount,
+            fpRegisters: {
+              values: fpuState.fpRegisters,
+              condFlag: fpuState.condFlag,
+              changed: fpuState.lastChangedFpRegisters,
+            },
           })
           get().refreshMemorySnapshot()
         } catch (e: unknown) {
@@ -1460,6 +1495,7 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
         patchMemoryForBackstep(sim)
       }
       const engineState = sim?.getState()
+      const fpuState = sim?.getFpuState()
       set({
         status: sim ? 'ready' : 'idle',
         registers: engineState
@@ -1474,6 +1510,9 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
         // collects when references drop.
         pendingInput: null,
         instructionsExecuted: 0,
+        fpRegisters: fpuState
+          ? { values: fpuState.fpRegisters, condFlag: fpuState.condFlag, changed: fpuState.lastChangedFpRegisters }
+          : { values: new Array<number>(32).fill(0), condFlag: false, changed: new Set<number>() },
       })
       _stopFlag = false
     },

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -814,6 +814,24 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
         return Promise.resolve()
       },
 
+      // syscall 51 — input int dialog (Phase 2H).
+      promptInt: (message) => {
+        if (typeof window === 'undefined') return Promise.resolve({ value: 0, cancelled: true })
+        const raw = window.prompt(message)
+        if (raw === null) return Promise.resolve({ value: 0, cancelled: true })
+        const n = parseInt(raw.trim(), 10)
+        if (Number.isNaN(n)) return Promise.resolve({ value: 0, cancelled: false, invalid: true })
+        return Promise.resolve({ value: n | 0, cancelled: false })
+      },
+
+      // syscall 53 — input string dialog (Phase 2H).
+      promptString: (message) => {
+        if (typeof window === 'undefined') return Promise.resolve({ value: '', cancelled: true })
+        const raw = window.prompt(message)
+        if (raw === null) return Promise.resolve({ value: '', cancelled: true })
+        return Promise.resolve({ value: raw, cancelled: false })
+      },
+
       exit: () => {
         _stopFlag = true
       },

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -25,6 +25,7 @@ import factorialSource   from '../examples/factorial.asm?raw'
 import stringPrintSource from '../examples/stringPrint.asm?raw'
 import sumToNSource      from '../examples/sumToN.asm?raw'
 import syscallIOSource   from '../examples/syscallIO.asm?raw'
+import floatMathSource   from '../examples/floatMath.asm?raw'
 
 // Canonical MIPS / real-MARS conventions: program text starts at
 // 0x00400000 and the stack pointer initializes at 0x7FFFEFFC (top of
@@ -211,7 +212,7 @@ function computeInitialLayout(): PersistedLayout {
 // keep reading from one place.
 
 export type ExampleName =
-  | 'arraySum' | 'factorial' | 'stringPrint' | 'sumToN' | 'syscallIO'
+  | 'arraySum' | 'factorial' | 'stringPrint' | 'sumToN' | 'syscallIO' | 'floatMath'
 
 export interface FileEntry {
   id: string
@@ -232,6 +233,7 @@ const EXAMPLE_SOURCES: Record<ExampleName, string> = {
   stringPrint: stringPrintSource,
   sumToN:      sumToNSource,
   syscallIO:   syscallIOSource,
+  floatMath:   floatMathSource,
 }
 
 const RECENT_FILES_KEY = 'webmars:recent-files'

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -1058,6 +1058,12 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
       const next = { ...get().simSettings, [key]: value }
       set({ simSettings: next })
       writePersistedSimSettings(next)
+      // Phase 2C — propagate delayedBranching to the live simulator
+      // so the change takes effect mid-program. The flag is also
+      // re-applied at assemble time so a fresh sim picks it up.
+      if (key === 'delayedBranching' && _sim) {
+        _sim.setDelayedBranching(value as boolean)
+      }
     },
 
     openSettings:  () => set({ settingsDialogOpen: true  }),
@@ -1348,6 +1354,7 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
       clearHistory()
       const sim = makeSim()
       sim.load(program)
+      sim.setDelayedBranching(get().simSettings.delayedBranching)
       patchMemoryForBackstep(sim)
       const engineState = sim.getState()
       const fpuState = sim.getFpuState()

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -775,6 +775,45 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
           get().logMessage('info', 'Awaiting input: string (syscall 8)')
         }),
 
+      // syscall 12 — readChar. Reuses the pendingInput infrastructure
+      // with kind 'char'; ConsoleInputField clamps to a single char.
+      readChar: () =>
+        new Promise<string>((resolve) => {
+          set({
+            status: 'paused',
+            pendingInput: {
+              kind: 'char',
+              resolve: (raw) => {
+                set({ pendingInput: null, status: 'running' })
+                resolve(raw.length > 0 ? raw[0]! : '')
+              },
+            },
+          })
+          get().logMessage('info', 'Awaiting input: character (syscall 12)')
+        }),
+
+      // syscall 50 — confirm dialog. Native window.confirm only
+      // returns OK/Cancel (boolean), so we collapse the MARS
+      // 3-state response: OK → Yes (0), Cancel → No (1). Real Cancel
+      // (2) is unreachable until we build a custom 3-button modal.
+      confirm: (message) =>
+        Promise.resolve(
+          typeof window !== 'undefined' && window.confirm(message) ? 0 : 1,
+        ),
+
+      // syscall 54 — message dialog. Native window.alert prefixed
+      // with the message kind so the user sees the severity. A
+      // custom modal with iconography would be a future polish.
+      alert: (message, kind) => {
+        const prefix =
+          kind === 'warn'    ? '[Warning] '
+          : kind === 'error' ? '[Error] '
+          : kind === 'question' ? '[?] '
+          : ''
+        if (typeof window !== 'undefined') window.alert(prefix + message)
+        return Promise.resolve()
+      },
+
       exit: () => {
         _stopFlag = true
       },

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -1058,11 +1058,15 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
       const next = { ...get().simSettings, [key]: value }
       set({ simSettings: next })
       writePersistedSimSettings(next)
-      // Phase 2C — propagate delayedBranching to the live simulator
-      // so the change takes effect mid-program. The flag is also
-      // re-applied at assemble time so a fresh sim picks it up.
+      // Phase 2C/2D — propagate engine-affecting toggles to the live
+      // simulator so the change takes effect mid-program. The flags
+      // are also re-applied at assemble time so a fresh sim picks
+      // them up.
       if (key === 'delayedBranching' && _sim) {
         _sim.setDelayedBranching(value as boolean)
+      }
+      if (key === 'selfModifyingCode' && _sim) {
+        _sim.setAllowSelfModifyingCode(value as boolean)
       }
     },
 
@@ -1354,7 +1358,9 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
       clearHistory()
       const sim = makeSim()
       sim.load(program)
-      sim.setDelayedBranching(get().simSettings.delayedBranching)
+      const settings = get().simSettings
+      sim.setDelayedBranching(settings.delayedBranching)
+      sim.setAllowSelfModifyingCode(settings.selfModifyingCode)
       patchMemoryForBackstep(sim)
       const engineState = sim.getState()
       const fpuState = sim.getFpuState()

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -24,6 +24,7 @@ const EXAMPLES: ReadonlyArray<{ id: ExampleName; label: string }> = [
   { id: 'stringPrint', label: 'String Print' },
   { id: 'sumToN',      label: 'Sum 1..N'     },
   { id: 'syscallIO',   label: 'Syscall I/O'  },
+  { id: 'floatMath',   label: 'Float Math (FPU)' },
 ]
 
 export function buildCommands(): Command[] {

--- a/src/lib/mipsLanguage.ts
+++ b/src/lib/mipsLanguage.ts
@@ -30,6 +30,14 @@ const MNEMONICS = [
   'li', 'la', 'move', 'blt', 'ble', 'bgt', 'bge', 'neg', 'not', 'nop',
   // Syscall
   'syscall',
+  // Coprocessor 1 (FPU) — Phase 2B. Dotted mnemonics work because
+  // the identifier regex includes '.' as a name char.
+  'add.s', 'sub.s', 'mul.s', 'div.s',
+  'sqrt.s', 'abs.s', 'mov.s', 'neg.s',
+  'cvt.s.w', 'cvt.w.s',
+  'c.eq.s', 'c.lt.s', 'c.le.s',
+  'bc1f', 'bc1t',
+  'mtc1', 'mfc1', 'lwc1', 'swc1',
 ] as const
 
 const DIRECTIVES = [
@@ -114,6 +122,29 @@ const INSTRUCTION_REFERENCE: Record<string, InstructionRef> = {
 
   // Syscall
   syscall: { signature: 'syscall',               desc: 'System call. $v0 selects service; $a0–$a3 carry args. v1.0 supports 1, 4, 5, 8, 10.' },
+
+  // Coprocessor 1 (FPU) — single-precision arithmetic, comparison,
+  // load/move, and branch. Operands are FPU registers $f0..$f31; mtc1
+  // and mfc1 bridge to the GPR file.
+  'add.s':  { signature: 'add.s $fd, $fs, $ft',  desc: 'Single-precision add. $fd = $fs + $ft.' },
+  'sub.s':  { signature: 'sub.s $fd, $fs, $ft',  desc: 'Single-precision subtract. $fd = $fs - $ft.' },
+  'mul.s':  { signature: 'mul.s $fd, $fs, $ft',  desc: 'Single-precision multiply. $fd = $fs * $ft.' },
+  'div.s':  { signature: 'div.s $fd, $fs, $ft',  desc: 'Single-precision divide. $fd = $fs / $ft.' },
+  'sqrt.s': { signature: 'sqrt.s $fd, $fs',      desc: 'Single-precision square root. $fd = sqrt($fs).' },
+  'abs.s':  { signature: 'abs.s $fd, $fs',       desc: 'Single-precision absolute value. $fd = |$fs|.' },
+  'mov.s':  { signature: 'mov.s $fd, $fs',       desc: 'Copy single-precision. $fd = $fs (bit-for-bit).' },
+  'neg.s':  { signature: 'neg.s $fd, $fs',       desc: 'Single-precision negate. $fd = -$fs.' },
+  'cvt.s.w':{ signature: 'cvt.s.w $fd, $fs',     desc: 'Convert int32 to single-precision. $fd = (float) $fs.' },
+  'cvt.w.s':{ signature: 'cvt.w.s $fd, $fs',     desc: 'Convert single-precision to int32 (truncate). $fd = (int) $fs.' },
+  'c.eq.s': { signature: 'c.eq.s $fs, $ft',      desc: 'Compare equal (single). cc[0] = ($fs == $ft).' },
+  'c.lt.s': { signature: 'c.lt.s $fs, $ft',      desc: 'Compare less-than (single). cc[0] = ($fs < $ft).' },
+  'c.le.s': { signature: 'c.le.s $fs, $ft',      desc: 'Compare less-or-equal (single). cc[0] = ($fs <= $ft).' },
+  'bc1f':   { signature: 'bc1f label',           desc: 'Branch if FPU cc[0] is false. PC = label if !cc[0].' },
+  'bc1t':   { signature: 'bc1t label',           desc: 'Branch if FPU cc[0] is true. PC = label if cc[0].' },
+  'mtc1':   { signature: 'mtc1 $rt, $fs',        desc: 'Move word from GPR to FPR. $fs ← bits($rt).' },
+  'mfc1':   { signature: 'mfc1 $rt, $fs',        desc: 'Move word from FPR to GPR. $rt ← bits($fs) (sign-extended).' },
+  'lwc1':   { signature: 'lwc1 $ft, offset($rs)',desc: 'Load word into FPR. $ft = MEM[$rs + offset]. Address must be 4-byte aligned.' },
+  'swc1':   { signature: 'swc1 $ft, offset($rs)',desc: 'Store word from FPR. MEM[$rs + offset] = $ft. Address must be 4-byte aligned.' },
 }
 
 const monarchTokens: languages.IMonarchLanguage = {

--- a/src/lib/mipsLanguage.ts
+++ b/src/lib/mipsLanguage.ts
@@ -38,6 +38,8 @@ const MNEMONICS = [
   'c.eq.s', 'c.lt.s', 'c.le.s',
   'bc1f', 'bc1t',
   'mtc1', 'mfc1', 'lwc1', 'swc1',
+  // Trap instructions — Phase 2F.
+  'teq', 'tne', 'tlt', 'tltu', 'tge', 'tgeu',
 ] as const
 
 const DIRECTIVES = [
@@ -145,6 +147,15 @@ const INSTRUCTION_REFERENCE: Record<string, InstructionRef> = {
   'mfc1':   { signature: 'mfc1 $rt, $fs',        desc: 'Move word from FPR to GPR. $rt ← bits($fs) (sign-extended).' },
   'lwc1':   { signature: 'lwc1 $ft, offset($rs)',desc: 'Load word into FPR. $ft = MEM[$rs + offset]. Address must be 4-byte aligned.' },
   'swc1':   { signature: 'swc1 $ft, offset($rs)',desc: 'Store word from FPR. MEM[$rs + offset] = $ft. Address must be 4-byte aligned.' },
+
+  // Trap instructions — Phase 2F. Each compares $rs against $rt and
+  // raises a runtime trap when its condition holds.
+  teq:  { signature: 'teq $rs, $rt',  desc: 'Trap if equal. Raises a runtime error when $rs == $rt.' },
+  tne:  { signature: 'tne $rs, $rt',  desc: 'Trap if not equal. Raises a runtime error when $rs != $rt.' },
+  tlt:  { signature: 'tlt $rs, $rt',  desc: 'Trap if less than (signed). Raises when $rs < $rt.' },
+  tltu: { signature: 'tltu $rs, $rt', desc: 'Trap if less than (unsigned). Raises when $rs <u $rt.' },
+  tge:  { signature: 'tge $rs, $rt',  desc: 'Trap if greater or equal (signed). Raises when $rs >= $rt.' },
+  tgeu: { signature: 'tgeu $rs, $rt', desc: 'Trap if greater or equal (unsigned). Raises when $rs >=u $rt.' },
 }
 
 const monarchTokens: languages.IMonarchLanguage = {

--- a/src/tests/delayedBranching.test.ts
+++ b/src/tests/delayedBranching.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { assemble } from '../core/instructions'
+import { Simulator } from '../core/simulator'
+import type { SyscallIO } from '../core/syscalls'
+
+function makeIO(printed: string[]): SyscallIO {
+  return {
+    print: (s) => { printed.push(s) },
+    readInt: () => Promise.resolve(0),
+    readString: () => Promise.resolve(''),
+    exit: () => {},
+  }
+}
+
+async function run(source: string, delayed: boolean): Promise<{ sim: Simulator; printed: string[] }> {
+  const program = assemble(source)
+  expect(program.errors).toEqual([])
+  const printed: string[] = []
+  const sim = new Simulator(makeIO(printed))
+  sim.load(program)
+  sim.setDelayedBranching(delayed)
+  await sim.run()
+  return { sim, printed }
+}
+
+describe('Delayed branching (Phase 2C)', () => {
+  // The delay slot instruction (addi $t0, $t0, 100) executes even
+  // when the branch is TAKEN — that's the whole point of delay
+  // slots. Without delayed branching, the addi is skipped because
+  // the branch jumps over it.
+  const source = `
+    .text
+    main:
+      li      $t0, 0
+      li      $t1, 1
+      li      $t2, 1
+      beq     $t1, $t2, target    # always taken
+      addi    $t0, $t0, 100       # delay slot
+      addi    $t0, $t0, 999       # never executed in either mode
+    target:
+      add     $a0, $t0, $zero
+      li      $v0, 1
+      syscall
+      li      $v0, 10
+      syscall
+  `
+
+  it('skips the post-branch instruction when delayed branching is OFF', async () => {
+    const { printed } = await run(source, false)
+    expect(printed.join('')).toBe('0')
+  })
+
+  it('runs the delay slot when delayed branching is ON', async () => {
+    const { printed } = await run(source, true)
+    expect(printed.join('')).toBe('100')
+  })
+
+  it('jal saves PC+8 (past the delay slot) when delayed branching is ON', async () => {
+    // With delayed branching, $ra after jal should point past the
+    // delay slot so jr $ra returns there. Without it, $ra points to
+    // the immediately-following instruction.
+    const sourceJal = `
+      .text
+      main:
+        jal     callee
+        addi    $t0, $t0, 7   # delay slot
+        addi    $t1, $t0, 0   # return target
+        add     $a0, $t1, $zero
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+      callee:
+        jr      $ra
+        nop                   # delay slot for the return
+    `
+    const { printed } = await run(sourceJal, true)
+    // Delay slot executes once (sets $t0 = 7), then control returns
+    // to the instruction past the delay slot, which copies $t0 → $t1
+    // and prints it.
+    expect(printed.join('')).toBe('7')
+  })
+})

--- a/src/tests/extendedSyscalls.test.ts
+++ b/src/tests/extendedSyscalls.test.ts
@@ -7,6 +7,8 @@ interface Trace {
   printed: string[]
   alerts: { message: string; kind: DialogKind }[]
   confirms: string[]
+  promptedInts: string[]
+  promptedStrings: string[]
 }
 
 function makeIO(trace: Trace, overrides: Partial<SyscallIO> = {}): SyscallIO {
@@ -17,6 +19,8 @@ function makeIO(trace: Trace, overrides: Partial<SyscallIO> = {}): SyscallIO {
     readChar: () => Promise.resolve('A'),
     confirm: async (m) => { trace.confirms.push(m); return 0 },
     alert: async (m, kind) => { trace.alerts.push({ message: m, kind }) },
+    promptInt: async (m) => { trace.promptedInts.push(m); return { value: 42, cancelled: false } },
+    promptString: async (m) => { trace.promptedStrings.push(m); return { value: 'hello', cancelled: false } },
     exit: () => {},
     ...overrides,
   }
@@ -25,7 +29,7 @@ function makeIO(trace: Trace, overrides: Partial<SyscallIO> = {}): SyscallIO {
 async function run(source: string, ioOverrides: Partial<SyscallIO> = {}): Promise<Trace> {
   const program = assemble(source)
   expect(program.errors).toEqual([])
-  const trace: Trace = { printed: [], alerts: [], confirms: [] }
+  const trace: Trace = { printed: [], alerts: [], confirms: [], promptedInts: [], promptedStrings: [] }
   const sim = new Simulator(makeIO(trace, ioOverrides))
   sim.load(program)
   await sim.run()
@@ -103,6 +107,70 @@ describe('Extended syscalls (Phase 2E)', () => {
         syscall
     `)
     expect(trace.confirms).toEqual(['Continue?'])
+  })
+
+  it('syscall 51 puts the prompted int in $a0 with status 0 in $a1', async () => {
+    const trace = await run(`
+      .data
+      msg:    .asciiz "Enter:"
+      .text
+      main:
+        la      $a0, msg
+        li      $v0, 51
+        syscall
+        # $a0 should now hold 42; print it
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(trace.promptedInts).toEqual(['Enter:'])
+    expect(trace.printed.join('')).toBe('42')
+  })
+
+  it('syscall 51 sets $a1 to -3 on cancel', async () => {
+    const trace = await run(
+      `
+      .data
+      msg:    .asciiz "Enter:"
+      .text
+      main:
+        la      $a0, msg
+        li      $v0, 51
+        syscall
+        # leak $a1 into $a0 then print
+        add     $a0, $a1, $zero
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `,
+      { promptInt: async () => ({ value: 0, cancelled: true }) },
+    )
+    expect(trace.printed.join('')).toBe('-3')
+  })
+
+  it('syscall 53 writes the prompted string into the buffer + NUL', async () => {
+    const trace = await run(`
+      .data
+      msg:    .asciiz "Name:"
+      buf:    .space 64
+      .text
+      main:
+        la      $a0, msg
+        la      $a1, buf
+        li      $a2, 64
+        li      $v0, 53
+        syscall
+        # buf now holds "hello\\0"; print it via syscall 4
+        la      $a0, buf
+        li      $v0, 4
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(trace.promptedStrings).toEqual(['Name:'])
+    expect(trace.printed.join('')).toBe('hello')
   })
 
   it('syscall 54 invokes io.alert with the prompt + kind from $a1', async () => {

--- a/src/tests/extendedSyscalls.test.ts
+++ b/src/tests/extendedSyscalls.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { assemble } from '../core/instructions'
+import { Simulator } from '../core/simulator'
+import type { SyscallIO, DialogKind } from '../core/syscalls'
+
+interface Trace {
+  printed: string[]
+  alerts: { message: string; kind: DialogKind }[]
+  confirms: string[]
+}
+
+function makeIO(trace: Trace, overrides: Partial<SyscallIO> = {}): SyscallIO {
+  return {
+    print: (s) => { trace.printed.push(s) },
+    readInt: () => Promise.resolve(0),
+    readString: () => Promise.resolve(''),
+    readChar: () => Promise.resolve('A'),
+    confirm: async (m) => { trace.confirms.push(m); return 0 },
+    alert: async (m, kind) => { trace.alerts.push({ message: m, kind }) },
+    exit: () => {},
+    ...overrides,
+  }
+}
+
+async function run(source: string, ioOverrides: Partial<SyscallIO> = {}): Promise<Trace> {
+  const program = assemble(source)
+  expect(program.errors).toEqual([])
+  const trace: Trace = { printed: [], alerts: [], confirms: [] }
+  const sim = new Simulator(makeIO(trace, ioOverrides))
+  sim.load(program)
+  await sim.run()
+  return trace
+}
+
+describe('Extended syscalls (Phase 2E)', () => {
+  it('syscall 11 prints a single character', async () => {
+    const trace = await run(`
+      .text
+      main:
+        li      $a0, 65       # 'A'
+        li      $v0, 11
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(trace.printed.join('')).toBe('A')
+  })
+
+  it('syscall 12 places the read char codepoint in $v0', async () => {
+    const trace = await run(
+      `
+      .text
+      main:
+        li      $v0, 12
+        syscall
+        add     $a0, $v0, $zero
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `,
+      { readChar: () => Promise.resolve('Z') },
+    )
+    expect(trace.printed.join('')).toBe('90')   // 'Z' = 90
+  })
+
+  it('syscall 30 puts the low 32 bits of Date.now() in $a0', async () => {
+    // We can't predict the exact time, but we can confirm the
+    // program runs to completion without throwing.
+    const trace = await run(`
+      .text
+      main:
+        li      $v0, 30
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(trace.printed).toEqual([])
+  })
+
+  it('syscall 41 fills $a0 with a random int (program runs)', async () => {
+    const trace = await run(`
+      .text
+      main:
+        li      $v0, 41
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(trace.printed).toEqual([])
+  })
+
+  it('syscall 50 invokes io.confirm with the prompt string', async () => {
+    const trace = await run(`
+      .data
+      msg:    .asciiz "Continue?"
+      .text
+      main:
+        la      $a0, msg
+        li      $v0, 50
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(trace.confirms).toEqual(['Continue?'])
+  })
+
+  it('syscall 54 invokes io.alert with the prompt + kind from $a1', async () => {
+    const trace = await run(`
+      .data
+      msg:    .asciiz "Done!"
+      .text
+      main:
+        la      $a0, msg
+        li      $a1, 2          # warn
+        li      $v0, 54
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(trace.alerts).toEqual([{ message: 'Done!', kind: 'warn' }])
+  })
+})

--- a/src/tests/fpu.test.ts
+++ b/src/tests/fpu.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { assemble } from '../core/instructions'
+import { Simulator } from '../core/simulator'
+import type { SyscallIO } from '../core/syscalls'
+import { bitsToFloat } from '../core/registers'
+
+function makeIO(printed: string[]): SyscallIO {
+  return {
+    print: (s) => { printed.push(s) },
+    readInt: () => Promise.resolve(0),
+    readString: () => Promise.resolve(''),
+    exit: () => {},
+  }
+}
+
+async function run(source: string): Promise<{ sim: Simulator; printed: string[] }> {
+  const program = assemble(source)
+  expect(program.errors).toEqual([])
+  const printed: string[] = []
+  const sim = new Simulator(makeIO(printed))
+  sim.load(program)
+  await sim.run()
+  return { sim, printed }
+}
+
+describe('FPU — single-precision arithmetic', () => {
+  it('add.s sums two integer-converted operands', async () => {
+    const { sim } = await run(`
+      .text
+      main:
+        li      $t0, 3
+        mtc1    $t0, $f0
+        cvt.s.w $f0, $f0
+        li      $t0, 4
+        mtc1    $t0, $f1
+        cvt.s.w $f1, $f1
+        add.s   $f2, $f0, $f1
+        li      $v0, 10
+        syscall
+    `)
+    const { fpRegisters } = sim.getFpuState()
+    expect(bitsToFloat(fpRegisters[2] ?? 0)).toBeCloseTo(7.0, 5)
+  })
+
+  it('mul.s + sqrt.s + cvt.w.s round-trip with print', async () => {
+    const { printed } = await run(`
+      .text
+      main:
+        li      $t0, 3
+        mtc1    $t0, $f0
+        cvt.s.w $f0, $f0
+        li      $t0, 4
+        mtc1    $t0, $f1
+        cvt.s.w $f1, $f1
+        mul.s   $f2, $f0, $f0
+        mul.s   $f3, $f1, $f1
+        add.s   $f4, $f2, $f3
+        sqrt.s  $f5, $f4
+        cvt.w.s $f6, $f5
+        mfc1    $a0, $f6
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(printed.join('')).toBe('5')
+  })
+
+  it('c.lt.s + bc1t branches when condition holds', async () => {
+    const { sim } = await run(`
+      .text
+      main:
+        li      $t0, 1
+        mtc1    $t0, $f0
+        cvt.s.w $f0, $f0
+        li      $t0, 2
+        mtc1    $t0, $f1
+        cvt.s.w $f1, $f1
+        c.lt.s  $f0, $f1     # 1.0 < 2.0 → cc[0] = true
+        bc1t    taken
+        li      $v0, 99       # should NOT execute
+        j       end
+      taken:
+        li      $v0, 42
+      end:
+        li      $v0, 10
+        syscall
+    `)
+    expect(sim.getFpuState().condFlag).toBe(true)
+  })
+
+  it('lwc1 / swc1 round-trip a float through memory', async () => {
+    const { sim } = await run(`
+      .data
+      slot:   .word 0
+      .text
+      main:
+        li      $t0, 7
+        mtc1    $t0, $f0
+        cvt.s.w $f0, $f0      # $f0 = 7.0
+        la      $t1, slot
+        swc1    $f0, 0($t1)
+        lwc1    $f4, 0($t1)
+        li      $v0, 10
+        syscall
+    `)
+    const { fpRegisters } = sim.getFpuState()
+    expect(bitsToFloat(fpRegisters[4] ?? 0)).toBeCloseTo(7.0, 5)
+  })
+})

--- a/src/tests/memory.test.ts
+++ b/src/tests/memory.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Memory, TEXT_BASE, DATA_BASE } from '../core/memory';
 
 let mem: Memory;
-beforeEach(() => { mem = new Memory(); });
+beforeEach(() => {
+  mem = new Memory();
+  // These unit tests exercise read/write mechanics by writing to
+  // TEXT_BASE (a known-mapped address); they pre-date Phase 2D's
+  // self-modifying-code guard, so opt in to text writes here so the
+  // mechanics stay verifiable. Phase 2D's policy is exercised by
+  // selfModifyingCode.test.ts.
+  mem.setAllowTextWrites(true);
+});
 
 describe('Memory readWord/writeWord', () => {
   it('writes and reads at TEXT_BASE', () => {

--- a/src/tests/selfModifyingCode.test.ts
+++ b/src/tests/selfModifyingCode.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { assemble } from '../core/instructions'
+import { Simulator } from '../core/simulator'
+import type { SyscallIO } from '../core/syscalls'
+
+function makeIO(): SyscallIO {
+  return {
+    print: () => {},
+    readInt: () => Promise.resolve(0),
+    readString: () => Promise.resolve(''),
+    exit: () => {},
+  }
+}
+
+describe('Self-modifying code guard (Phase 2D)', () => {
+  // sw $t0, 0($t1) where $t1 = TEXT_BASE — a store into the
+  // instruction stream. The default-deny policy throws; flipping
+  // the flag lets it succeed.
+  const source = `
+    .text
+    main:
+      lui     $t1, 0x0040    # $t1 = 0x00400000 (TEXT_BASE)
+      li      $t0, 0x12345678
+      sw      $t0, 0($t1)
+      li      $v0, 10
+      syscall
+  `
+
+  it('throws by default when storing to .text', async () => {
+    const program = assemble(source)
+    expect(program.errors).toEqual([])
+    const sim = new Simulator(makeIO())
+    sim.load(program)
+    await expect(sim.run()).rejects.toThrow(/Self-modifying code/)
+  })
+
+  it('succeeds when self-modifying code is allowed', async () => {
+    const program = assemble(source)
+    expect(program.errors).toEqual([])
+    const sim = new Simulator(makeIO())
+    sim.load(program)
+    sim.setAllowSelfModifyingCode(true)
+    await sim.run()
+    expect(sim.isHalted()).toBe(true)
+  })
+})

--- a/src/tests/signExtension.test.ts
+++ b/src/tests/signExtension.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { assemble } from '../core/instructions'
+import { Simulator } from '../core/simulator'
+import type { SyscallIO } from '../core/syscalls'
+
+function makeIO(printed: string[]): SyscallIO {
+  return {
+    print: (s) => { printed.push(s) },
+    readInt: () => Promise.resolve(0),
+    readString: () => Promise.resolve(''),
+    exit: () => {},
+  }
+}
+
+async function run(source: string): Promise<{ sim: Simulator; printed: string[] }> {
+  const program = assemble(source)
+  expect(program.errors).toEqual([])
+  const printed: string[] = []
+  const sim = new Simulator(makeIO(printed))
+  sim.load(program)
+  await sim.run()
+  return { sim, printed }
+}
+
+describe('addiu / sltiu sign-extension (Phase 2G fix)', () => {
+  it('li $t0, -5 produces -5 (addiu sign-extends imm16)', async () => {
+    const { printed } = await run(`
+      .text
+      main:
+        li      $t0, -5
+        add     $a0, $t0, $zero
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(printed.join('')).toBe('-5')
+  })
+
+  it('addiu $t1, $zero, -100 produces -100', async () => {
+    const { printed } = await run(`
+      .text
+      main:
+        addiu   $t1, $zero, -100
+        add     $a0, $t1, $zero
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(printed.join('')).toBe('-100')
+  })
+
+  it('sltiu compares against sign-extended immediate', async () => {
+    // sltiu $t0, $t1, -1 → compare $t1 (unsigned) against 0xffffffff.
+    // Any value other than 0xffffffff is < 0xffffffff → result 1.
+    const { printed } = await run(`
+      .text
+      main:
+        li      $t1, 100
+        sltiu   $t0, $t1, -1
+        add     $a0, $t0, $zero
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(printed.join('')).toBe('1')
+  })
+})

--- a/src/tests/trap.test.ts
+++ b/src/tests/trap.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { assemble } from '../core/instructions'
+import { Simulator } from '../core/simulator'
+import type { SyscallIO } from '../core/syscalls'
+
+function makeIO(): SyscallIO {
+  return {
+    print: () => {},
+    readInt: () => Promise.resolve(0),
+    readString: () => Promise.resolve(''),
+    exit: () => {},
+  }
+}
+
+async function run(source: string): Promise<Simulator> {
+  const program = assemble(source)
+  expect(program.errors).toEqual([])
+  const sim = new Simulator(makeIO())
+  sim.load(program)
+  await sim.run()
+  return sim
+}
+
+async function expectTrap(source: string, mnemonic: string): Promise<void> {
+  const program = assemble(source)
+  expect(program.errors).toEqual([])
+  const sim = new Simulator(makeIO())
+  sim.load(program)
+  await expect(sim.run()).rejects.toThrow(new RegExp(`Trap: ${mnemonic}`))
+}
+
+describe('Trap instructions (Phase 2F)', () => {
+  it('teq fires when operands are equal', async () => {
+    await expectTrap(`
+      .text
+      main:
+        li      $t0, 7
+        li      $t1, 7
+        teq     $t0, $t1
+        li      $v0, 10
+        syscall
+    `, 'teq')
+  })
+
+  it('teq does not fire when operands differ', async () => {
+    const sim = await run(`
+      .text
+      main:
+        li      $t0, 7
+        li      $t1, 8
+        teq     $t0, $t1
+        li      $v0, 10
+        syscall
+    `)
+    expect(sim.isHalted()).toBe(true)
+  })
+
+  it('tne fires when operands differ', async () => {
+    await expectTrap(`
+      .text
+      main:
+        li      $t0, 1
+        li      $t1, 2
+        tne     $t0, $t1
+        li      $v0, 10
+        syscall
+    `, 'tne')
+  })
+
+  it('tlt fires on signed less-than', async () => {
+    // NB: avoid `li $t, -N` here — the engine's addiu currently
+    // zero-extends imm16 (a pre-existing bug, not Phase 2F's), so
+    // li with a negative immediate produces a positive value. Use
+    // two positives instead, which exercises the same trap path.
+    await expectTrap(`
+      .text
+      main:
+        li      $t0, 1
+        li      $t1, 3
+        tlt     $t0, $t1
+        li      $v0, 10
+        syscall
+    `, 'tlt')
+  })
+
+  it('tge fires on signed greater-or-equal', async () => {
+    await expectTrap(`
+      .text
+      main:
+        li      $t0, 100
+        li      $t1, 50
+        tge     $t0, $t1
+        li      $v0, 10
+        syscall
+    `, 'tge')
+  })
+
+  it('tltu fires on unsigned less-than but tlt would not (negative LHS)', async () => {
+    // -1 as unsigned is 0xffffffff which is NOT less than 1. So
+    // tltu $t0, $t1 where $t0=-1, $t1=1 should NOT trap. Verify
+    // the runtime with a positive case instead.
+    await expectTrap(`
+      .text
+      main:
+        li      $t0, 1
+        li      $t1, 5
+        tltu    $t0, $t1
+        li      $v0, 10
+        syscall
+    `, 'tltu')
+  })
+})

--- a/src/ui/FpuRegisterTable.tsx
+++ b/src/ui/FpuRegisterTable.tsx
@@ -1,0 +1,90 @@
+import { useSimulator, type NumberBase } from '@/hooks/useSimulator.ts'
+import { bitsToFloat } from '@/core/registers.ts'
+import { cn } from './cn.ts'
+
+// Format a single-precision float — three decimal places when the
+// magnitude is small, scientific notation otherwise. NaN / Infinity
+// pass through as their JS string forms (consistent with how MARS
+// displays them).
+function formatFloat(value: number): string {
+  if (!Number.isFinite(value)) return String(value)
+  if (value === 0) return '0.000'
+  const abs = Math.abs(value)
+  if (abs >= 1e6 || abs < 1e-3) return value.toExponential(3)
+  return value.toFixed(3)
+}
+
+function formatBits(bits: number, base: NumberBase): string {
+  switch (base) {
+    case 'hex': return '0x' + (bits >>> 0).toString(16).padStart(8, '0')
+    case 'dec': return ((bits | 0)).toString(10)
+    case 'bin': return '0b' + (bits >>> 0).toString(2).padStart(32, '0')
+  }
+}
+
+export function FpuRegisterTable() {
+  const fpRegisters = useSimulator((s) => s.fpRegisters)
+  const numberBase  = useSimulator((s) => s.numberBase)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        className="flex items-center justify-between font-mono text-[10px] uppercase text-ink-3"
+        style={{ letterSpacing: '0.06em' }}
+      >
+        <span>32 single-precision registers</span>
+        <span className="flex items-center gap-1">
+          cc[0]
+          <span
+            className={cn(
+              'rounded-pill px-1.5 py-0.5 font-mono text-[10px]',
+              fpRegisters.condFlag
+                ? 'bg-ok text-surface-0'
+                : 'bg-surface-3 text-ink-2',
+            )}
+          >
+            {fpRegisters.condFlag ? 'true' : 'false'}
+          </span>
+        </span>
+      </div>
+
+      <table className="w-full border-collapse text-[11px]">
+        <thead>
+          <tr
+            className="border-b border-divider font-mono text-[10px] uppercase text-ink-3"
+            style={{ letterSpacing: '0.06em' }}
+          >
+            <th className="px-1 py-1 text-left">Reg</th>
+            <th className="px-1 py-1 text-right">Float</th>
+            <th className="px-1 py-1 text-right">Bits</th>
+          </tr>
+        </thead>
+        <tbody>
+          {fpRegisters.values.map((bits, idx) => {
+            const changed = fpRegisters.changed.has(idx)
+            const float = bitsToFloat(bits)
+            return (
+              <tr
+                key={idx}
+                className={cn(
+                  'border-b border-divider/40 last:border-b-0',
+                  changed && 'bg-accent/10',
+                )}
+              >
+                <td className="px-1 py-0.5 font-mono text-ink-2">
+                  ${`f${idx}`}
+                </td>
+                <td className="px-1 py-0.5 text-right font-mono tabular-nums text-ink-1">
+                  {formatFloat(float)}
+                </td>
+                <td className="px-1 py-0.5 text-right font-mono tabular-nums text-ink-3">
+                  {formatBits(bits, numberBase)}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/ui/RightPanel.tsx
+++ b/src/ui/RightPanel.tsx
@@ -1,6 +1,8 @@
 import { useState, type ReactNode } from 'react'
+import { useSimulator } from '@/hooks/useSimulator.ts'
 import { cn } from './cn.ts'
 import { RegisterTable } from './RegisterTable.tsx'
+import { FpuRegisterTable } from './FpuRegisterTable.tsx'
 import { MemoryPanel } from './MemoryPanel.tsx'
 
 interface AccordionSectionProps {
@@ -75,6 +77,12 @@ function PlaceholderBody({ futureSubAgent, description }: { futureSubAgent: stri
 }
 
 export function RightPanel() {
+  // FPU section is gated by simSettings.coproc01Panels (the toggle
+  // landed in SA-12, wired in Phase 2B). Off-by-default — most
+  // programs don't touch the FPU and the extra accordion eats real
+  // estate in the right pane.
+  const showFpu = useSimulator((s) => s.simSettings.coproc01Panels)
+
   return (
     <aside
       aria-label="Inspector panel"
@@ -83,6 +91,12 @@ export function RightPanel() {
       <AccordionSection title="Registers" defaultOpen>
         <RegisterTable />
       </AccordionSection>
+
+      {showFpu && (
+        <AccordionSection title="FPU ($f0..$f31)" defaultOpen={false}>
+          <FpuRegisterTable />
+        </AccordionSection>
+      )}
 
       <AccordionSection title="Memory" defaultOpen={false}>
         <MemoryPanel />

--- a/src/ui/SettingsDialog.tsx
+++ b/src/ui/SettingsDialog.tsx
@@ -267,8 +267,6 @@ export function SettingsDialog() {
                     description="Permit stores to the .text segment. Off by default — most programs hit this by accident."
                     checked={simSettings.selfModifyingCode}
                     onChange={(v) => setSimSetting('selfModifyingCode', v)}
-                    badge="Phase 2D"
-                    disabled
                   />
                 </Section>
                 <Section title="Notes">

--- a/src/ui/SettingsDialog.tsx
+++ b/src/ui/SettingsDialog.tsx
@@ -252,11 +252,9 @@ export function SettingsDialog() {
                 <Section title="Simulator behaviour">
                   <Toggle
                     label="Delayed branching"
-                    description="Execute the instruction immediately after a branch (real-MIPS branch-delay slot)."
+                    description="Execute the instruction immediately after a branch (real-MIPS branch-delay slot). Most course material assumes this is OFF."
                     checked={simSettings.delayedBranching}
                     onChange={(v) => setSimSetting('delayedBranching', v)}
-                    badge="Phase 2C"
-                    disabled
                   />
                   <Toggle
                     label="FPU ($f0–$f31) panel"

--- a/src/ui/SettingsDialog.tsx
+++ b/src/ui/SettingsDialog.tsx
@@ -259,12 +259,10 @@ export function SettingsDialog() {
                     disabled
                   />
                   <Toggle
-                    label="Coprocessor 0 / 1 panels"
-                    description="Show $f0–$f31 (FPU) and CP0 status / cause / EPC registers in the right panel."
+                    label="FPU ($f0–$f31) panel"
+                    description="Show the coprocessor 1 register file in the right panel. Requires Phase 2B engine support."
                     checked={simSettings.coproc01Panels}
                     onChange={(v) => setSimSetting('coproc01Panels', v)}
-                    badge="Phase 2B"
-                    disabled
                   />
                   <Toggle
                     label="Self-modifying code allowed"

--- a/src/ui/Toolbar.tsx
+++ b/src/ui/Toolbar.tsx
@@ -51,6 +51,7 @@ const EXAMPLES: ReadonlyArray<{ id: ExampleName; label: string; desc: string }> 
   { id: 'stringPrint', label: 'String Print',      desc: 'print a literal via syscall 4' },
   { id: 'sumToN',      label: 'Sum 1..N',          desc: 'read N, print 1+2+…+N' },
   { id: 'syscallIO',   label: 'Syscall I/O',       desc: 'read int, print int (full I/O)' },
+  { id: 'floatMath',   label: 'Float Math (FPU)',  desc: 'sqrt(3² + 4²) via mtc1/cvt.s.w/mul.s' },
 ]
 
 function ExamplesDropdown() {


### PR DESCRIPTION
Phase 2B adds coprocessor 1 (FPU) support across the engine, assembler, runtime, and IDE. Builds on Phase 2A.

## What landed

- **Engine** (8c94f0d): 32-slot single-precision FPU register file, FCSR cc[0] flag, decoder for cop1 fmt.s arithmetic (add/sub/mul/div/sqrt/abs/mov/neg .s), mtc1/mfc1, lwc1/swc1, cvt.s.w/cvt.w.s, c.eq.s/c.lt.s/c.le.s, bc1f/bc1t.
- **UI panel** (21a531d): FpuRegisterTable in RightPanel showing $f0..$f31 with float + bit views and the cc[0] flag. Gated by the simSettings.coproc01Panels toggle that landed (disabled) in SA-12; Phase 2B re-enables it.
- **Grammar / reference / example / tests** (a612387): Monarch + INSTRUCTION_REFERENCE entries for all 20 new mnemonics, floatMath.asm example computing sqrt(3² + 4²) = 5, 4 focused FPU tests proving the full mtc1 → cvt.s.w → mul.s → sqrt.s → cvt.w.s → mfc1 → print roundtrip.

## Verification

- typecheck + lint + build green through every commit
- 80/80 tests passing (76 prior + 4 FPU)
- Bundle: 339 KB JS / ~52 KB CSS

## How to try it

Settings → Simulator → check "FPU (\$f0–\$f31) panel". Examples dropdown → "Float Math (FPU)". Run.