### PR TITLE
docs: add v1.0 demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The project is built in TypeScript with React, Vite, and Tailwind CSS, and runs 
 
 v1.0 ready. Every PRD must-have and stretch goal shipped; 103 tests passing; full MARS feature parity for the curriculum we target.
 
-See [the PRD](./docs/PRD.md) for the full scope, timeline, and roadmap, or [the final report](./docs/FINAL_REPORT.md) for the project writeup.
+See [the PRD](./docs/PRD.md) for the full scope, timeline, and roadmap, [the final report](./docs/FINAL_REPORT.md) for the project writeup, or [the demo script](./docs/DEMO_SCRIPT.md) for a seven-minute walkthrough.
 
 ## Features
 

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,0 +1,130 @@
+# WebMARS Demo Script
+
+A walkthrough script for demonstrating WebMARS v1.0 in roughly seven minutes. Designed to be read out loud at a normal speaking pace, with each numbered step describing both the action to take and what to say while taking it.
+
+---
+
+## Setup checklist (do this before starting)
+
+1. Open the deployed Vercel build, or run `npm run dev` and open the URL Vite prints (5173 by default; check the terminal output if another project is using that port).
+2. Confirm the default file `hello.asm` is loaded in the editor.
+3. Confirm the right inspector is open with the Registers section expanded.
+4. Confirm the bottom panel is open and showing the Console tab.
+5. If you plan to demo themes, leave the theme on dark to start. The light and high-contrast themes are part of the demo.
+6. If you plan to demo the FPU, do not enable the FPU panel yet. The settings dialog is part of the demo.
+7. Have one source file with a deliberate typo ready as a backup, in case the inline-error portion of the demo needs a fresh trigger.
+
+Total run time: about seven minutes if you do every section. Each section is independent and can be cut for time.
+
+---
+
+## Section 1: Pitch (about 30 seconds)
+
+**Say:** "WebMARS is a browser-based MIPS assembler and runtime simulator. The original MARS tool from Missouri State has been the standard for teaching MIPS for over twenty years, but it ships as a Java desktop application that students need to install on every machine they use. WebMARS removes that step. It runs entirely in the browser, requires no install, and presents a layout that resembles modern code editors. We built it as a final project for our computer architecture course over a six-day sprint."
+
+**Action:** Gesture to the screen so the audience sees the shell. Do not click anything yet.
+
+---
+
+## Section 2: The default workflow (about 90 seconds)
+
+**Say:** "The default file is a Hello, MIPS program. Let me walk through the standard write, assemble, run loop that students do every day."
+
+**Action 1:** Click **Assemble** in the toolbar.
+**Say:** "Assemble runs the two-pass MIPS32 assembler in the core. The status pill in the top right flips to Ready, and you can see in the Messages tab at the bottom that two instructions assembled."
+
+**Action 2:** Click **Run**.
+**Say:** "Run executes the program to completion. The Console tab shows the output. You can also see in the right panel that the program counter has advanced and several registers updated."
+
+**Action 3:** Click **Reset**, then click **Step** three times in a row.
+**Say:** "Reset returns the simulator to its initial state without re-assembling. Step advances one instruction at a time. Watch the registers on the right: any register that just changed flashes briefly in cyan. The PC value updates with each step, and you can see exactly which syscall is about to fire by looking at $v0."
+
+---
+
+## Section 3: Examples and console input (about 60 seconds)
+
+**Action 1:** Open the **Examples** dropdown in the toolbar.
+**Say:** "We bundle six example programs. Let me load Sum 1 to N, which is the canonical syscall I/O example."
+
+**Action 2:** Click **Sum 1..N**.
+
+**Action 3:** Click **Run**. When the prompt appears in the console, type `5` and press Enter.
+**Say:** "When the program calls syscall 5 to read an integer, the console drops in an inline input field. The simulator pauses until you submit. Type a value, press Enter, and the program continues. The result is the sum from 1 to 5, which is 15."
+
+---
+
+## Section 4: Editor errors and debugging (about 90 seconds)
+
+**Action 1:** Click into the editor and add a typo. For example, change `add` to `addd` on any line.
+**Say:** "Monaco shows assembler errors inline as red squiggles, with hover messages that explain what went wrong."
+
+**Action 2:** Click the **Problems** tab in the bottom panel.
+**Say:** "The Problems panel aggregates every assembler and runtime error. Clicking an entry jumps the editor cursor to the offending line."
+
+**Action 3:** Click the error in Problems to demonstrate the jump. Then fix the typo back to `add` and Assemble again.
+
+**Action 4:** Click in the editor gutter (the area to the left of the line numbers) on any executable line. A red dot appears.
+**Say:** "Click in the gutter to set a breakpoint. Breakpoints persist per file in localStorage. The Breakpoints panel in the left rail lists every active breakpoint with a preview of its source line and a click-to-jump action."
+
+**Action 5:** Click **Run** again. The program halts at the breakpoint.
+
+**Action 6:** Click **Backstep** twice.
+**Say:** "Backstep is the most interesting debugging feature. The simulator keeps a circular history of register and memory snapshots, so you can rewind recent steps and watch the inspector revert. This is something the original MARS does not do."
+
+---
+
+## Section 5: FPU and the settings dialog (about 60 seconds)
+
+**Action 1:** Open the **Settings** menu and click **Open Settings**, or press `Ctrl+,`.
+**Say:** "We support three themes, an editor font slider, and three simulator toggles. The toggles are real-MIPS behaviors that most courses teach in their second half."
+
+**Action 2:** Switch to the **Simulator** tab in the dialog. Check **FPU panel**.
+**Say:** "Enabling the FPU panel exposes the coprocessor 1 register file in the right inspector. We support 20 single-precision FPU instructions, the FCSR condition flag, and integer-to-float and float-to-integer conversions."
+
+**Action 3:** Close the dialog. Open the Examples dropdown and click **Float Math (FPU)**.
+
+**Action 4:** Expand the **FPU ($f0..$f31)** section in the right panel. Click **Run**.
+**Say:** "This program computes the square root of three squared plus four squared. Watch $f0 through $f6 fill in as the program executes. The final result is 5, which prints in the console."
+
+---
+
+## Section 6: Polish (about 60 seconds)
+
+**Action 1:** Press `Ctrl+Shift+P`.
+**Say:** "Command palette. Every action in the application is reachable from here with fuzzy search. This is the same pattern as VS Code."
+
+**Action 2:** Type `theme` to filter. Click **Theme: Light**.
+**Say:** "We ship dark, light, and high-contrast themes. Theme choice persists across reloads."
+
+**Action 3:** Switch back to dark via the palette or the Settings menu.
+
+**Action 4:** Resize the browser window narrow, below 768 pixels wide.
+**Say:** "Below 768 pixels the shell collapses to a read-only editor with a banner. The full IDE is built for desktop workflows, but mobile users can still read code, open files, and view assembly without breaking the layout."
+
+**Action 5:** Restore the browser width.
+
+---
+
+## Section 7: Close (about 30 seconds)
+
+**Say:** "WebMARS v1.0 ships every must-have feature in our PRD plus all six listed stretch goals. The codebase is 103 unit and integration tests, a 345 KB JavaScript bundle, and a strict separation between the simulator core and the React UI so the engine can be tested without mounting any UI. The full project writeup is in docs slash FINAL_REPORT.md, and the supported instruction set, syscalls, and known limitations are in the README. Thanks for watching."
+
+---
+
+## If something goes wrong during the demo
+
+- **Vercel build is unreachable:** fall back to `npm run dev` locally. The dev server starts in under a second on any modern machine.
+- **A syscall input freezes the demo:** the Console tab shows a pending input field. If it does not, click **Reset** and try the example again.
+- **Assemble produces an unexpected error:** check the Messages tab. Every error includes a line number. If you cannot resolve it live, switch to a different example.
+- **The audience asks about pipeline timing, hazards, forwarding, or cache:** these are out of scope for v1.0. Reference section 4 of the final report (What We Cut) for the full list.
+- **The audience asks about coprocessor 0 or double-precision FPU:** these are deferred to a future phase. Reference section 5 of the final report (What We Would Do Next).
+- **The audience asks about the original MARS:** acknowledge it directly. WebMARS is built as a tribute, not a replacement of the educational model. The acknowledgements section of the README credits Pete Sanderson and Kenneth Vollmar.
+
+---
+
+## Variants by time budget
+
+- **Two minutes:** Sections 1, 2, and 7 only. Skip examples, debugging, FPU, and polish.
+- **Five minutes:** Sections 1, 2, 3, 4, and 7. Skip FPU and polish. This is the strongest cut for a tight time slot.
+- **Seven minutes:** every section in order, as scripted above.
+- **Ten minutes:** every section, plus open the Tools menu and demo the Instruction Counter, plus enable the delayed-branching toggle and step through a `beq` followed by an `addi` to show the delay slot fire.


### PR DESCRIPTION
PRD section 6 day 6 lists "demo script written" as a Day 6 exit criterion alongside the final report. This PR delivers it.

## Document

- 1,454 words
- Seven sections covering pitch, default workflow, examples + console input, editor errors + debugging, FPU + settings, polish, and close
- Each section calls out roughly how long it should take and gives both the action to take and the line to say
- Setup checklist at the top, troubleshooting block at the bottom for live-demo failure modes
- Time-budget variants at the end (two, five, seven, ten minutes)
- No em dashes, no emojis, easy language, professional tone
- Linked from the README Status section alongside the PRD and final report