### PR TITLE
docs(readme): replace Vercel TBD placeholder with live URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The v1.0 release targets the workflows students rely on most.
 
 ## Getting Started
 
-WebMARS is published as a static web build and requires no installation to use. Visit the deployed URL — _TBD: Vercel deploy in progress_ — and you can begin writing MIPS assembly in your browser. See [`docs/VERCEL_DEPLOY.md`](./docs/VERCEL_DEPLOY.md) for the deploy walkthrough.
+WebMARS is published as a static web build and requires no installation to use. The live build is at **[webmarsimulator.com](https://www.webmarsimulator.com/)** — open it in a Chromium-based browser (Chrome, Edge, Brave, Arc) for the full feature set. See [`docs/VERCEL_DEPLOY.md`](./docs/VERCEL_DEPLOY.md) for the deploy walkthrough.
 
 To run the project locally for development, follow the instructions below.
 


### PR DESCRIPTION
Vercel deploy went live at https://www.webmarsimulator.com/. README Getting Started no longer carries the placeholder; it now links to the deployed build and notes the Chromium recommendation.