### PR TITLE
docs: refresh README + final report + demo script for v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,30 +14,57 @@ See [the PRD](./docs/PRD.md) for the full scope, timeline, and roadmap, [the fin
 
 ## Features
 
-The v1.0 release targets the workflows students rely on most.
+The v1.1.0 release covers every workflow the curriculum needs, plus a Tools menu that goes well beyond the original PRD.
 
-### Core
+### Editor and assembler
 
-- Source editor with MIPS syntax highlighting and hover docs (Monaco).
-- Inline assembler-error squiggles plus an error overview ruler in the editor margin.
-- Two-pass MIPS32 assembler covering roughly fifty instructions across arithmetic, logical, branch, jump, load/store, FPU, and trap families.
-- Pseudo-instruction support for `li`, `la`, `move`, `blt`, `ble`, `bgt`, `bge`, `neg`, `not`, `nop`.
-- Instruction-set simulator with a full 32-register integer file, 32-register single-precision FPU, HI/LO, FCSR cc[0], program counter, and a configurable text/data/stack memory layout.
-- Run, Pause, Step, Backstep (snapshot history with memory-write rewind), Run-to-cursor, Reset controls plus a 1–500 instr/s speed slider.
-- Live register file with per-step change highlighting; toggleable hex / decimal / binary views.
-- Toggleable FPU panel showing $f0–$f31 in float and bits.
-- Memory inspector with segment toggle (`.text` / `.data` / stack), base-address jump, edit-in-place, and a flash on each write.
+- Monaco editor with custom MIPS syntax highlighting and hover docs.
+- Inline assembler-error squiggles plus an error overview ruler in the margin.
+- Low-opacity breakpoint preview on gutter hover so users discover where to click.
+- Two-pass MIPS32 assembler covering ~60 instructions across arithmetic, logical, shift, branch, jump, load/store, FPU, and trap families.
+- Pseudo-instructions: `li`, `la`, `move`, `blt`, `ble`, `bgt`, `bge`, `abs`, `sge`, `sgt`, `neg`, `not`, `nop`.
+- `.globl` directive accepted as a no-op for single-file assembly.
+
+### Runtime and debugging
+
+- Run, Pause, Step, Backstep, Run-to-cursor, Reset controls plus a 1–500 instr/s speed slider.
+- Backstep rewinds register state AND memory writes via a 200-entry circular snapshot history.
 - Click-to-set breakpoints in the editor gutter, persisted per file.
-- Bottom panel: Console, Messages, Problems. Console handles syscall I/O via an inline input field; Problems aggregates assembler + runtime errors with click-to-jump.
-- File system: multi-file tabs (drag to reorder), File System Access API integration for native open/save with a download fallback in non-Chromium browsers, Open Recent submenu.
-- Bundled example programs covering array sum, factorial, string print, sum 1..N, syscall I/O, and FPU floating-point math.
-- Symbol table panel resolving labels to addresses with click-to-jump.
-- Searchable instruction reference panel.
-- Settings dialog: dark / light / high-contrast themes, editor font size, simulator toggles (FPU panel, delayed branching, self-modifying code).
+- Live register file with per-step change highlighting; toggleable hex / decimal / binary views.
+- Toggleable FPU panel showing $f0–$f31 in float and bits along with the FCSR cc[0] flag.
+- Memory inspector with segment toggle (`.text` / `.data` / stack), base-address jump, edit-in-place, and a flash on each write.
+- Console handles syscall I/O via an inline input field; Messages and Problems panels aggregate runtime + assembler errors with click-to-jump.
+
+### File system and editor shell
+
+- Multi-file tabs with drag-to-reorder, right-click context menu, and an Open Recent submenu.
+- File System Access API for native open/save in Chromium browsers; download fallback in Firefox.
+- Resizable panels — drag the strip between the source pane and the bottom panel, or between the center and the right inspector. Sizes persist across reloads. Keyboard accessible (arrow keys nudge, Home resets).
+- Bundled example programs: array sum, factorial, string print, sum 1..N, syscall I/O, FPU float math, MMIO keyboard echo.
+- Symbol table panel and searchable instruction reference panel in the left rail.
+- Settings cog at the bottom of the left rail opens the Settings dialog.
+
+### Settings, commands, keyboard
+
+- Settings dialog with dark / light / high-contrast themes, editor font size, simulator toggles (FPU panel, delayed branching, self-modifying code).
 - Command palette (`Ctrl+Shift+P`) with fuzzy search across every action.
-- Keyboard shortcuts (F3/F5/F6/F7/Shift+F7/F8/F9, Ctrl+S, Ctrl+O, Ctrl+N, Ctrl+B, Ctrl+J, Ctrl+,, …).
-- Tools menu featuring an Instruction Counter (static mnemonic histogram + runtime step count).
-- Mobile-friendly read-only mode under 768px viewport.
+- In-app help dialog (`F1` or the `?` button in the toolbar) with six tabs: Basic Instructions, Pseudo-Instructions, Directives, Syscalls, Exceptions, About.
+- Keyboard shortcuts: F1 help, F3 assemble, F5 run, F6 pause, F7 step, Shift+F7 backstep, F8 run to cursor, F9 toggle breakpoint, Ctrl+S save, Ctrl+O open, Ctrl+N new, Ctrl+G goto-line, Ctrl+F find, Ctrl+H replace, Ctrl+B/Ctrl+J/Ctrl+Alt+B layout, Ctrl+, settings.
+
+### Tools menu
+
+- **Instruction Counter** — static mnemonic histogram + runtime step count.
+- **Bitmap Display** — treats a region of memory as a 2D pixel grid; configurable cell size, dimensions, base address.
+- **Keyboard / Display MMIO** — memory-mapped I/O at 0xffff0000–0xffff000c with engine-side support and an interactive UI.
+- **Floating-Point Representation** — bit-level IEEE 754 single-precision editor with sign / exponent / mantissa decode.
+- **Memory Reference Visualization** — top-50 horizontal bar chart of accessed addresses.
+- **Screen Magnifier** — floating loupe overlay for projector demos.
+- Placeholders for v2.0: Cache Simulator, MIPS X-Ray, BHT Simulator, Digital Lab Sim, Scavenger Hunt, Mars Bot.
+
+### Mobile
+
+- Under 768px viewport, the shell switches to a tabbed mobile layout: hamburger drawer for menus, four tabs (Editor / Registers / Memory / Console), full-width control bar (Assemble / Run / Pause / Step / Reset).
+- The editor is read-only by default with an Edit toggle in the header. Word wrap is on; the minimap is hidden.
 
 ## Getting Started
 
@@ -210,21 +237,22 @@ Cross-checking simulator output against the original MARS for the same input is 
 
 **FPU — coprocessor 1, single-precision (Phase 2B):** `add.s`, `sub.s`, `mul.s`, `div.s`, `sqrt.s`, `abs.s`, `mov.s`, `neg.s`, `cvt.s.w`, `cvt.w.s`, `c.eq.s`, `c.lt.s`, `c.le.s`, `bc1f`, `bc1t`, `mtc1`, `mfc1`, `lwc1`, `swc1`. The FPU panel in the right inspector is gated behind a settings toggle.
 
-**Pseudo-instructions:** `li`, `la`, `move`, `blt`, `ble`, `bgt`, `bge`, `neg`, `not`, `nop`.
+**Pseudo-instructions:** `li`, `la`, `move`, `blt`, `ble`, `bgt`, `bge`, `abs`, `sge`, `sgt`, `neg`, `not`, `nop`.
 
 **Syscalls:** `1` (print int), `4` (print string), `5` (read int), `8` (read string), `10` (exit), `11` (print char), `12` (read char), `30` (system time), `32` (sleep), `41` (random int), `42` (random int range), `50` (confirm dialog), `51` (input int dialog), `53` (input string dialog), `54` (message dialog).
 
 ## Limitations
 
-WebMARS is intentionally scoped. The following are known limitations of v1.0 and are not bugs.
+WebMARS is intentionally scoped. The following are known limitations of v1.1.0 and are not bugs.
 
-- The MARS Tools menu (bitmap display, keyboard / MMIO simulator, cache simulator, memory reference visualization) is not implemented. Only the Instruction Counter from that menu ships.
+- Tools menu coverage is partial: Instruction Counter, Bitmap Display, Keyboard / Display MMIO, Floating-Point Representation, Memory Reference Visualization, and Screen Magnifier ship as real tools. Cache Simulator, MIPS X-Ray, BHT Simulator, Digital Lab Sim, Scavenger Hunt, and Mars Bot ship as placeholder modals describing the v2.0 plan.
 - No `.include` or macros, and no multi-file projects in the assembler sense — multi-file is editor-only.
 - FPU support is single-precision only. Double-precision (`.d` ops) and coprocessor 0 (`$status`, `$cause`, `$epc`, `mfc0`/`mtc0`/`eret`) are out of scope.
 - Branch-delay-slot semantics are off by default for teaching clarity. Real-MIPS delay-slot behavior can be opted into via Settings → Simulator → "Delayed branching"; when on, `jal`/`jalr` save PC+8 to skip the delay slot.
 - Self-modifying code is rejected by default (any store into the `.text` segment throws). Settings → Simulator → "Self-modifying code allowed" lifts the guard.
 - Pipeline timing, hazards, forwarding, and cache effects are not modeled. Instruction execution is sequential and atomic.
 - The `Confirm` dialog syscall (50) collapses MARS's three-state response (Yes / No / Cancel) to two states (OK → Yes, Cancel → No) because it uses the native `window.confirm`.
+- The Screen Magnifier renders a positioned overlay rectangle but does not currently mirror the underlying pixels at 2x. Full DOM-cloning magnification needs `html2canvas` or similar; out of scope for v1.1.0. Use the OS-level zoom for projector demos in the meantime.
 - Browser persistence is `localStorage`-only — layout, theme, recent files, breakpoints, and run speed survive a reload, but source code itself is not auto-saved. Use File → Save (or `Ctrl+S`) before closing the tab.
 - The File System Access API used for native Open / Save is Chromium-only. Firefox falls back to `<input type="file">` and a blob download.
 

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -88,26 +88,50 @@ Total run time: about seven minutes if you do every section. Each section is ind
 
 ---
 
-## Section 6: Polish (about 60 seconds)
+## Section 6: Tools menu (about 90 seconds, v1.1.0)
 
-**Action 1:** Press `Ctrl+Shift+P`.
-**Say:** "Command palette. Every action in the application is reachable from here with fuzzy search. This is the same pattern as VS Code."
+**Action 1:** Open the **Tools** menu in the menu bar.
+**Say:** "WebMARS v1.1 ships a real Tools menu. Six tools are working today, six more are placeholders for v2.0 with descriptions of what they will do."
 
-**Action 2:** Type `theme` to filter. Click **Theme: Light**.
-**Say:** "We ship dark, light, and high-contrast themes. Theme choice persists across reloads."
+**Action 2:** Click **Bitmap Display**. In the dialog, set the cell size to 8 and grid to 64. Click **Connect**.
+**Say:** "Bitmap Display treats memory as a 2D pixel grid. Each word is one RGB pixel. Run a program that writes color values into the data segment and watch them paint here. This is what students use to write Pong, Snake, and Game of Life."
 
-**Action 3:** Switch back to dark via the palette or the Settings menu.
+**Action 3:** Close the Bitmap Display. Open **Tools** → **Floating-Point Representation**.
+**Say:** "Type a decimal value, see the 32 bits. Click any bit to flip it. The decoded sign, exponent, and mantissa update live. Useful when teaching IEEE 754."
 
-**Action 4:** Resize the browser window narrow, below 768 pixels wide.
-**Say:** "Below 768 pixels the shell collapses to a read-only editor with a banner. The full IDE is built for desktop workflows, but mobile users can still read code, open files, and view assembly without breaking the layout."
+**Action 4:** Close the dialog. Open **Tools** → **Memory Reference Visualization**.
+**Say:** "Open this BEFORE running a program. It tracks every memory access and shows the top 50 addresses as a bar chart. Useful for teaching locality."
 
-**Action 5:** Restore the browser width.
+**Action 5:** Close the dialog. Press `F1`.
+**Say:** "F1 opens the in-app help dialog. Six tabs cover every supported instruction, every pseudo-op, every directive, every syscall, and the runtime exceptions. Filterable. No more flipping between WebMARS and the MARS PDF."
+
+**Action 6:** Close the help dialog.
 
 ---
 
-## Section 7: Close (about 30 seconds)
+## Section 7: Polish (about 60 seconds)
 
-**Say:** "WebMARS v1.0 ships every must-have feature in our PRD plus all six listed stretch goals. The codebase is 103 unit and integration tests, a 345 KB JavaScript bundle, and a strict separation between the simulator core and the React UI so the engine can be tested without mounting any UI. The full project writeup is in docs slash FINAL_REPORT.md, and the supported instruction set, syscalls, and known limitations are in the README. Thanks for watching."
+**Action 1:** Press `Ctrl+Shift+P`.
+**Say:** "Command palette. Every action in the application is reachable from here with fuzzy search. Same pattern as VS Code."
+
+**Action 2:** Type `theme` to filter. Click **Theme: Light**.
+**Say:** "Three themes ship: dark, light, and high contrast. Choice persists across reloads."
+
+**Action 3:** Switch back to dark via the palette or Settings.
+
+**Action 4:** Drag the strip between the source pane and the bottom panel. Then drag the strip between the center pane and the right inspector.
+**Say:** "v1.1 added drag-to-resize between the workspace regions. Sizes persist."
+
+**Action 5:** Resize the browser window narrow, below 768 pixels wide.
+**Say:** "Below 768 pixels the shell switches to a mobile layout: hamburger drawer for menus, four tabs for editor and inspector views, and a control bar at the bottom. The editor is read-only by default but the user can opt into editing through the header toggle."
+
+**Action 6:** Restore the browser width.
+
+---
+
+## Section 8: Close (about 30 seconds)
+
+**Say:** "WebMARS v1.1.0 ships every must-have feature in our PRD plus every listed stretch goal, plus a six-tool Tools menu, an in-app help dialog, drag-to-resize panels, and a real mobile shell. The codebase is 119 unit and integration tests, a 405 KB JavaScript bundle, and a strict separation between the simulator core and the React UI so the engine can be tested without mounting any UI. The deployed build is at webmarsimulator.com. The full project writeup is in docs slash FINAL_REPORT.md, and the supported instruction set is in the README. Thanks for watching."
 
 ---
 
@@ -124,7 +148,8 @@ Total run time: about seven minutes if you do every section. Each section is ind
 
 ## Variants by time budget
 
-- **Two minutes:** Sections 1, 2, and 7 only. Skip examples, debugging, FPU, and polish.
-- **Five minutes:** Sections 1, 2, 3, 4, and 7. Skip FPU and polish. This is the strongest cut for a tight time slot.
-- **Seven minutes:** every section in order, as scripted above.
-- **Ten minutes:** every section, plus open the Tools menu and demo the Instruction Counter, plus enable the delayed-branching toggle and step through a `beq` followed by an `addi` to show the delay slot fire.
+- **Two minutes:** Sections 1, 2, and 8 only. Skip examples, debugging, FPU, tools, and polish.
+- **Five minutes:** Sections 1, 2, 3, 4, and 8. Skip FPU, tools, and polish. This is the strongest cut for a tight time slot.
+- **Seven minutes:** Sections 1, 2, 3, 4, 5, 7, 8. Skip the Tools section.
+- **Nine minutes:** every section in order, as scripted above.
+- **Twelve minutes:** every section, plus enable the delayed-branching toggle and step through a `beq` followed by an `addi` to show the delay slot fire, plus open Tools → Keyboard / Display MMIO and load the MMIO Keyboard Echo example.

--- a/docs/FINAL_REPORT.md
+++ b/docs/FINAL_REPORT.md
@@ -82,3 +82,33 @@ Quality-of-life items include a custom three-button modal to replace the native 
 The test suite would benefit from a property-based pass against a reference MIPS interpreter, comparing register state after each step on randomly generated programs. This would catch the kind of edge cases that hand-written tests miss. The `addiu` sign-extension bug we found during Phase 2G is a good example: it had been in the engine since Day 2 and went undetected through every existing test because no test happened to use a negative immediate with that specific instruction.
 
 Finally, the deployed Vercel build needs to land before the project is fully delivered. The configuration already exists. The remaining work is mechanical: connect the GitHub repository to a Vercel project, confirm the build command and output directory, and update the README link from its current placeholder to the live URL.
+
+## 6. v1.1.0 Update: Phase 3 Bug-Fix Sweep
+
+After v1.0 shipped and went into use, a feedback list surfaced from real student programs and presentation prep. Phase 3 closes that list and adds a meaningful expansion of the Tools menu plus a real mobile shell. The work landed as a single squash-merged pull request covering 17 sub-agents.
+
+### Bugs fixed
+
+The most visible was a console rendering issue where the first character of the first print would be dropped. Programs that opened with `print_string "What is your age?"` rendered as "hat is your age?" until the user re-ran. The root cause was a render-timing race between the simulator's first call to `io.print` and the React tree's mount of the console panel. The fix was three-part: switch the store to a single accumulating `consoleBuffer` string and derive the legacy `consoleOutput` array from it, defer print updates through `queueMicrotask` so React commits the previous render before the next state lands, and always-mount all three bottom-panel tabs (Console, Messages, Problems) so the console is never absent from the tree at the moment a program first prints.
+
+The assembler was missing nine pseudo-instructions that real student programs leaned on: `blt`, `ble`, `bgt`, `bge`, `abs`, `sge`, `sgt`, `neg`, `not`. Each is now implemented as a textual expansion using `$at` as scratch, with the first-pass size accounting updated so that labels following a multi-instruction expansion resolve to the correct address. The `.globl` directive, which previously caused the symbol after it to be parsed as an unknown mnemonic, is now a no-op.
+
+A handful of UI bugs were also addressed: menu dropdowns scrolled past the viewport on small screens, the LeftRail settings cog did not open the Settings dialog, and the editor gutter gave no visual hint that it was clickable. Each got a focused fix.
+
+### New features
+
+The Tools menu, which previously had only Instruction Counter, gained five new working tools: Bitmap Display (treats memory as a 2D pixel grid), Keyboard / Display MMIO simulator (memory-mapped I/O at 0xffff0000–0xffff000c with engine support and a paired UI), Floating-Point Representation (bit-level IEEE 754 editor), Memory Reference Visualization (top-50 access bar chart), and Screen Magnifier (positioned overlay for projector demos). Six additional tools (Cache Simulator, MIPS X-Ray, BHT Simulator, Digital Lab Sim, Scavenger Hunt, Mars Bot) ship as placeholder modals describing their v2.0 scope.
+
+A new in-app Help dialog covers the full reference set across six tabs: Basic Instructions, Pseudo-Instructions, Directives, Syscalls, Exceptions, and About. The dialog is reachable from the toolbar's `?` button, the F1 key, or any of the Help menu items. The instruction reference data was consolidated into a single source of truth at `src/lib/instructionReference.ts` so the Monaco hover provider and the help dialog read from the same array.
+
+The shell itself gained drag-to-resize handles between the center pane and the right inspector and between the source pane and the bottom panel. Sizes persist across reloads and the handles are keyboard accessible.
+
+The mobile layout was rebuilt from scratch. The previous implementation collapsed the desktop shell into a read-only editor with a banner suggesting the user open a desktop browser. The new mobile shell is a real interface: a 56px header with a hamburger drawer for menus, a four-tab body (Editor / Registers / Memory / Console), and a 48px bottom control bar with the assemble / run / pause / step / reset operations. The editor remains read-only by default since typing assembly on a phone is painful, but the user can opt into editing through a header toggle.
+
+### Numbers
+
+v1.1.0 ships with 119 tests across 13 files, up from 103 in v1.0. The added tests cover the console first-byte regression (3 tests), the nine new pseudo-instructions (13 tests), and earlier-phase additions. The bundle grew to 405 KB of JavaScript (114 KB gzipped) plus 53 KB of CSS, up from 345 KB / 101 KB in v1.0. The growth comes mostly from the new tool modals, the help dialog reference data, and the mobile shell.
+
+### Deployment
+
+Vercel deploys WebMARS to https://www.webmarsimulator.com/ from every push to main.


### PR DESCRIPTION
Closes the v1.0 → v1.1.0 doc drift.

## README
- Features section is reorganized by area and enumerates every Phase 3 addition (Tools menu, resizable panels, in-app help dialog, mobile rework, breakpoint hover preview, new pseudo-ops).
- Pseudo-instructions list now includes abs, sge, sgt.
- Limitations section now describes the Tools menu as partial (six real, six placeholders) instead of saying it's not implemented.

## docs/FINAL_REPORT.md
- New section 6 covers Phase 3: the console first-byte bug fix, the nine new pseudo-instructions, the Tools menu expansion, the help dialog, the resize handles, and the mobile shell rebuild.
- Same style as v1.0 sections: easy language, no em dashes, no emojis.
- Includes the v1.1.0 numbers (119 tests, 405 KB JS bundle) and the deployed URL.

## docs/DEMO_SCRIPT.md
- New Section 6 demos three of the new tools (Bitmap, FP repr, Mem ref viz) plus F1 help.
- Section 7 adds the resize-handle demo and updates the mobile-mode walkthrough.
- Section 8 close updated with v1.1.0 stats + webmarsimulator.com.
- Time-budget variants reshuffled.