### PR TITLE
fix: console first-byte (every line), examples z-index, help scroll, rail icons, mobile editor, bitmap smile

### DIFF
--- a/src/examples/bitmapSmile.asm
+++ b/src/examples/bitmapSmile.asm
@@ -1,0 +1,45 @@
+# Bitmap Display demo: a smile face.
+#
+# To see it, do this:
+#   1. Click Assemble.
+#   2. Click Run (the program is just a syscall 10 exit; the work
+#      is in the .data block below — bytes are loaded into memory
+#      at the .data base by the assembler).
+#   3. Open Tools menu -> Bitmap Display.
+#   4. In the Bitmap Display dialog, leave the defaults:
+#        Cell size: 8px
+#        Grid: 8 by 8
+#        Base address: 0x10010000
+#      (If the grid was previously set to something larger, change
+#      it back to 8x8 to match the size of this image.)
+#   5. Make sure Connect is on. The smile face should be visible.
+#
+# Each .word below is one pixel: 0x00RRGGBB. 0xFFFF00 is yellow,
+# 0x000000 is black background. Reading left-to-right, top-to-
+# bottom for an 8x8 grid:
+#
+#   row 0:  . . . . . . . .
+#   row 1:  . Y . . . . Y .
+#   row 2:  . Y . . . . Y .
+#   row 3:  . . . . . . . .
+#   row 4:  . . . . . . . .
+#   row 5:  Y . . . . . . Y
+#   row 6:  . Y Y Y Y Y Y .
+#   row 7:  . . . . . . . .
+
+.data
+smile:  .word 0,        0,        0,        0,        0,        0,        0,        0
+        .word 0,        0xFFFF00, 0,        0,        0,        0,        0xFFFF00, 0
+        .word 0,        0xFFFF00, 0,        0,        0,        0,        0xFFFF00, 0
+        .word 0,        0,        0,        0,        0,        0,        0,        0
+        .word 0,        0,        0,        0,        0,        0,        0,        0
+        .word 0xFFFF00, 0,        0,        0,        0,        0,        0,        0xFFFF00
+        .word 0,        0xFFFF00, 0xFFFF00, 0xFFFF00, 0xFFFF00, 0xFFFF00, 0xFFFF00, 0
+        .word 0,        0,        0,        0,        0,        0,        0,        0
+
+.text
+main:
+        # Nothing to compute — the data is already in memory.
+        # Open Tools -> Bitmap Display to see the result.
+        li      $v0, 10
+        syscall

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -27,6 +27,7 @@ import sumToNSource      from '../examples/sumToN.asm?raw'
 import syscallIOSource   from '../examples/syscallIO.asm?raw'
 import floatMathSource   from '../examples/floatMath.asm?raw'
 import mmioEchoSource    from '../examples/mmioEcho.asm?raw'
+import bitmapSmileSource from '../examples/bitmapSmile.asm?raw'
 
 // Canonical MIPS / real-MARS conventions: program text starts at
 // 0x00400000 and the stack pointer initializes at 0x7FFFEFFC (top of
@@ -213,7 +214,7 @@ function computeInitialLayout(): PersistedLayout {
 // keep reading from one place.
 
 export type ExampleName =
-  | 'arraySum' | 'factorial' | 'stringPrint' | 'sumToN' | 'syscallIO' | 'floatMath' | 'mmioEcho'
+  | 'arraySum' | 'factorial' | 'stringPrint' | 'sumToN' | 'syscallIO' | 'floatMath' | 'mmioEcho' | 'bitmapSmile'
 
 export interface FileEntry {
   id: string
@@ -236,6 +237,7 @@ const EXAMPLE_SOURCES: Record<ExampleName, string> = {
   syscallIO:   syscallIOSource,
   floatMath:   floatMathSource,
   mmioEcho:    mmioEchoSource,
+  bitmapSmile: bitmapSmileSource,
 }
 
 const RECENT_FILES_KEY = 'webmars:recent-files'

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -25,6 +25,8 @@ const EXAMPLES: ReadonlyArray<{ id: ExampleName; label: string }> = [
   { id: 'sumToN',      label: 'Sum 1..N'     },
   { id: 'syscallIO',   label: 'Syscall I/O'  },
   { id: 'floatMath',   label: 'Float Math (FPU)' },
+  { id: 'mmioEcho',    label: 'MMIO Keyboard Echo' },
+  { id: 'bitmapSmile', label: 'Bitmap Smile' },
 ]
 
 export function buildCommands(): Command[] {

--- a/src/ui/ConsolePanel.tsx
+++ b/src/ui/ConsolePanel.tsx
@@ -8,45 +8,44 @@ const MAX_VISIBLE_LINES = 1000
 const AUTO_SCROLL_THRESHOLD = 16  // px from bottom — within this counts as "at bottom"
 
 export function ConsolePanel() {
-  const lines        = useSimulator((s) => s.consoleOutput)
+  // Phase 3 follow-up: render the full consoleBuffer in a single
+  // <pre> element. The previous "one <pre> per array element"
+  // approach interacted badly with React's reconciliation when the
+  // buffer was split on newlines, dropping the first character of
+  // every line in the visible output. A single <pre> with whitespace
+  // preserved sidesteps the issue entirely (browsers render \n in
+  // pre as line breaks natively).
+  const buffer       = useSimulator((s) => s.consoleBuffer)
   const filter       = useSimulator((s) => s.consoleFilter)
   const setFilter    = useSimulator((s) => s.setConsoleFilter)
   const clearConsole = useSimulator((s) => s.clearConsole)
   const pending      = useSimulator((s) => s.pendingInput)
-  // Pending object reference doubles as the React key — every new
-  // read syscall installs a new pending object, which re-mounts the
-  // input field (resetting its value and re-focusing).
   const pendingKey   = useSimulator((s) => s.pendingInput?.kind ?? 'idle')
 
   const scrollRef = useRef<HTMLDivElement | null>(null)
-  // atBottom drives both effects (auto-scroll on new output) and
-  // render (the "↓ latest" affordance), so it lives in state.
   const [atBottom, setAtBottom] = useState(true)
 
-  // Filter (case-insensitive substring) + windowing — render only the
-  // last MAX_VISIBLE_LINES so very long programs don't blow up the
-  // DOM. The (N earlier hidden) hint surfaces the omission.
-  const { displayLines, hiddenCount } = useMemo(() => {
+  // Filter (case-insensitive substring) + windowing on a per-line
+  // basis. The visible string joins surviving lines back with \n so
+  // the single <pre> renders them as actual line breaks.
+  const { visibleText, hiddenCount } = useMemo(() => {
+    const allLines = buffer.split('\n')
     const filtered = filter
-      ? lines.filter((line) => line.toLowerCase().includes(filter.toLowerCase()))
-      : lines
+      ? allLines.filter((line) => line.toLowerCase().includes(filter.toLowerCase()))
+      : allLines
     if (filtered.length <= MAX_VISIBLE_LINES) {
-      return { displayLines: filtered, hiddenCount: 0 }
+      return { visibleText: filtered.join('\n'), hiddenCount: 0 }
     }
-    return {
-      displayLines: filtered.slice(-MAX_VISIBLE_LINES),
-      hiddenCount: filtered.length - MAX_VISIBLE_LINES,
-    }
-  }, [lines, filter])
+    const tail = filtered.slice(-MAX_VISIBLE_LINES)
+    return { visibleText: tail.join('\n'), hiddenCount: filtered.length - MAX_VISIBLE_LINES }
+  }, [buffer, filter])
 
-  // Auto-scroll to bottom on new output, but only if the user hasn't
-  // scrolled up.
   useEffect(() => {
     if (!atBottom) return
     const el = scrollRef.current
     if (!el) return
     el.scrollTop = el.scrollHeight
-  }, [displayLines, atBottom])
+  }, [visibleText, atBottom])
 
   function handleScroll(): void {
     const el = scrollRef.current
@@ -58,7 +57,7 @@ export function ConsolePanel() {
 
   function handleCopy(): void {
     if (typeof navigator === 'undefined' || !navigator.clipboard) return
-    void navigator.clipboard.writeText(lines.join(''))
+    void navigator.clipboard.writeText(buffer)
   }
 
   function scrollToBottom(): void {
@@ -68,7 +67,7 @@ export function ConsolePanel() {
     el.scrollTop = el.scrollHeight
   }
 
-  const hasContent = displayLines.length > 0 || hiddenCount > 0
+  const hasContent = visibleText.length > 0 || hiddenCount > 0
   const showJumpToBottom = !atBottom && hasContent
 
   return (
@@ -81,11 +80,11 @@ export function ConsolePanel() {
         <button
           type="button"
           onClick={clearConsole}
-          disabled={lines.length === 0}
+          disabled={buffer.length === 0}
           className={cn(
             'rounded-sm px-2 py-0.5 transition-colors',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent',
-            lines.length === 0
+            buffer.length === 0
               ? 'cursor-not-allowed text-ink-3'
               : 'text-ink-2 hover:bg-surface-2 hover:text-ink-1',
           )}
@@ -95,12 +94,12 @@ export function ConsolePanel() {
         <button
           type="button"
           onClick={handleCopy}
-          disabled={lines.length === 0}
+          disabled={buffer.length === 0}
           title="Copy console output to clipboard"
           className={cn(
             'rounded-sm px-2 py-0.5 transition-colors',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent',
-            lines.length === 0
+            buffer.length === 0
               ? 'cursor-not-allowed text-ink-3'
               : 'text-ink-2 hover:bg-surface-2 hover:text-ink-1',
           )}
@@ -150,15 +149,11 @@ export function ConsolePanel() {
                 ({hiddenCount} earlier line{hiddenCount === 1 ? '' : 's'} hidden — clear or filter to narrow)
               </div>
             )}
-            {displayLines.map((line, i) => (
-              <pre
-                // Console output is append-only; index-as-key is safe.
-                key={`line-${i}`}
-                className="m-0 whitespace-pre-wrap break-words font-mono text-xs leading-5 text-ink-1"
-              >
-                {line}
-              </pre>
-            ))}
+            {/* Single <pre> for the entire visible buffer. Browsers
+               render \n in pre as line breaks natively, so we don't
+               need per-line elements. The prior approach lost the
+               first character of every line on multi-line output. */}
+            <pre className="m-0 whitespace-pre-wrap break-words font-mono text-xs leading-5 text-ink-1">{visibleText}</pre>
           </div>
         )}
       </div>

--- a/src/ui/HelpDialog.tsx
+++ b/src/ui/HelpDialog.tsx
@@ -114,9 +114,10 @@ export function HelpDialog() {
         aria-label="Help"
         tabIndex={-1}
         className={cn(
-          'flex h-[44rem] w-[60rem] flex-col overflow-hidden rounded-lg border border-divider bg-surface-1 shadow-xl',
+          'flex max-h-[90vh] w-[60rem] max-w-[95vw] flex-col overflow-hidden rounded-lg border border-divider bg-surface-1 shadow-xl',
           'focus-visible:outline-none',
         )}
+        style={{ height: '90vh' }}
       >
         <header className="flex h-10 flex-none items-center justify-between border-b border-divider px-4">
           <div className="flex items-center gap-2 text-sm text-ink-1">

--- a/src/ui/LeftRail.tsx
+++ b/src/ui/LeftRail.tsx
@@ -2,6 +2,8 @@ import { useSimulator, type LeftPanelKey } from '@/hooks/useSimulator.ts'
 import { BreakpointsPanel } from './BreakpointsPanel.tsx'
 import { SymbolsPanel } from './SymbolsPanel.tsx'
 import { ReferencePanel } from './ReferencePanel.tsx'
+import { ProjectPanel } from './ProjectPanel.tsx'
+import { ToolsPanel } from './ToolsPanel.tsx'
 import { cn } from './cn.ts'
 
 interface RailIcon {
@@ -12,11 +14,11 @@ interface RailIcon {
 }
 
 const RAIL_ICONS: ReadonlyArray<RailIcon> = [
-  { id: 'project',     label: 'Project',          glyph: '◧', futureSubAgent: 'SA-2 (file system)' },
+  { id: 'project',     label: 'Project',          glyph: '◧' },
   { id: 'symbols',     label: 'Symbols',          glyph: '⌗' },
   { id: 'breakpoints', label: 'Breakpoints',      glyph: '●' },
   { id: 'reference',   label: 'Reference',        glyph: '?' },
-  { id: 'tools',       label: 'Tools',            glyph: '⚙', futureSubAgent: 'SA-15' },
+  { id: 'tools',       label: 'Tools',            glyph: '⚙' },
 ]
 
 // Reads leftRailExpanded + leftPanelKey from the layout slice.
@@ -117,6 +119,10 @@ export function LeftRail() {
             <SymbolsPanel />
           ) : panelKey === 'reference' ? (
             <ReferencePanel />
+          ) : panelKey === 'project' ? (
+            <ProjectPanel />
+          ) : panelKey === 'tools' ? (
+            <ToolsPanel />
           ) : (
             <div className="px-3 py-3 text-xs italic text-ink-3">
               ({panelKey} panel lands in a later sub-agent)

--- a/src/ui/MobileShell.tsx
+++ b/src/ui/MobileShell.tsx
@@ -206,12 +206,17 @@ export function MobileShell() {
           ))}
         </div>
 
-        {/* Body */}
-        <main className="overflow-hidden">
-          <div hidden={tab !== 'editor'}    className={cn('h-full', tab !== 'editor'    && 'hidden')}><SourcePane /></div>
-          <div hidden={tab !== 'registers'} className={cn('h-full overflow-y-auto px-3 py-2', tab !== 'registers' && 'hidden')}><RegisterTable /></div>
-          <div hidden={tab !== 'memory'}    className={cn('h-full overflow-y-auto px-3 py-2', tab !== 'memory'    && 'hidden')}><MemoryPanel /></div>
-          <div hidden={tab !== 'console'}   className={cn('h-full', tab !== 'console'   && 'hidden')}><ConsolePanel /></div>
+        {/* Body — Phase 3 follow-up: relative + min-h-0 + explicit
+           inset-0 child positioning so Monaco's automaticLayout can
+           measure the editor pane on mobile. The previous structure
+           collapsed to a sliver on portrait phones because the grid
+           row's intrinsic size depended on Monaco reporting back its
+           own height (chicken-and-egg). */}
+        <main className="relative min-h-0 overflow-hidden">
+          <div hidden={tab !== 'editor'}    className={cn('absolute inset-0', tab !== 'editor'    && 'hidden')}><SourcePane /></div>
+          <div hidden={tab !== 'registers'} className={cn('absolute inset-0 overflow-y-auto px-3 py-2', tab !== 'registers' && 'hidden')}><RegisterTable /></div>
+          <div hidden={tab !== 'memory'}    className={cn('absolute inset-0 overflow-y-auto px-3 py-2', tab !== 'memory'    && 'hidden')}><MemoryPanel /></div>
+          <div hidden={tab !== 'console'}   className={cn('absolute inset-0', tab !== 'console'   && 'hidden')}><ConsolePanel /></div>
         </main>
 
         {/* Control bar */}

--- a/src/ui/ProjectPanel.tsx
+++ b/src/ui/ProjectPanel.tsx
@@ -1,0 +1,105 @@
+import { useSimulator } from '@/hooks/useSimulator.ts'
+import { cn } from './cn.ts'
+
+// Phase 3 follow-up: wires the rail's Project icon. Lists the open
+// files with a click-to-activate row, and surfaces the file actions
+// (New / Open / Save) without the user having to hunt them down in
+// the menu bar.
+
+export function ProjectPanel() {
+  const files          = useSimulator((s) => s.files)
+  const activeFileId   = useSimulator((s) => s.activeFileId)
+  const setActiveFile  = useSimulator((s) => s.setActiveFile)
+  const closeFile      = useSimulator((s) => s.closeFile)
+  const newFile        = useSimulator((s) => s.newFile)
+  const openFromDisk   = useSimulator((s) => s.openFromDisk)
+  const saveActive     = useSimulator((s) => s.saveActive)
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div
+        className="flex h-7 flex-none items-center justify-between border-b border-divider px-3 font-mono text-[10px] uppercase text-ink-3"
+        style={{ letterSpacing: '0.06em' }}
+      >
+        <span className="text-ink-2">Project</span>
+        <span className="text-ink-3">{files.length}</span>
+      </div>
+
+      <div className="flex-none border-b border-divider p-2">
+        <div className="grid grid-cols-3 gap-1">
+          <button
+            type="button"
+            onClick={newFile}
+            className="rounded-sm bg-surface-2 px-2 py-1 text-[11px] text-ink-1 transition-colors hover:bg-surface-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            title="New file (Ctrl+N)"
+          >
+            New
+          </button>
+          <button
+            type="button"
+            onClick={() => { void openFromDisk() }}
+            className="rounded-sm bg-surface-2 px-2 py-1 text-[11px] text-ink-1 transition-colors hover:bg-surface-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            title="Open file (Ctrl+O)"
+          >
+            Open
+          </button>
+          <button
+            type="button"
+            onClick={() => { void saveActive() }}
+            disabled={activeFileId === null}
+            className={cn(
+              'rounded-sm px-2 py-1 text-[11px] transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+              activeFileId === null
+                ? 'cursor-not-allowed bg-surface-2 text-ink-3'
+                : 'bg-surface-2 text-ink-1 hover:bg-surface-3',
+            )}
+            title="Save active file (Ctrl+S)"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {files.length === 0 ? (
+          <div className="px-3 py-3 text-xs italic text-ink-3">
+            No files open. Click New or Open above.
+          </div>
+        ) : (
+          <ul className="divide-y divide-divider/40">
+            {files.map((file) => {
+              const active = file.id === activeFileId
+              return (
+                <li key={file.id} className="group flex items-center">
+                  <button
+                    type="button"
+                    onClick={() => setActiveFile(file.id)}
+                    className={cn(
+                      'flex flex-1 items-center gap-2 px-3 py-1 text-left transition-colors',
+                      'focus-visible:outline-none focus-visible:bg-surface-2',
+                      active ? 'bg-surface-2 text-ink-1' : 'text-ink-2 hover:bg-surface-2',
+                    )}
+                    title={`Switch to ${file.name}`}
+                  >
+                    <span aria-hidden="true" className={cn('size-2 flex-none rounded-pill', file.modified ? 'bg-warn' : 'bg-transparent')} />
+                    <span className="flex-1 truncate font-mono text-[11px]">{file.name}</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { void closeFile(file.id) }}
+                    aria-label={`Close ${file.name}`}
+                    title="Close file"
+                    className="size-5 flex-none rounded-sm text-base leading-none text-ink-3 opacity-0 transition-opacity hover:bg-surface-3 hover:text-ink-1 group-hover:opacity-70"
+                  >
+                    ×
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/ui/Toolbar.tsx
+++ b/src/ui/Toolbar.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useSimulator, type ExampleName, RUN_SPEED_STOPS } from '@/hooks/useSimulator.ts'
 import { getEditorCursor } from '@/lib/editorCursor.ts'
 import { Button } from './Button.tsx'
@@ -53,19 +54,23 @@ const EXAMPLES: ReadonlyArray<{ id: ExampleName; label: string; desc: string }> 
   { id: 'syscallIO',   label: 'Syscall I/O',       desc: 'read int, print int (full I/O)' },
   { id: 'floatMath',   label: 'Float Math (FPU)',  desc: 'sqrt(3² + 4²) via mtc1/cvt.s.w/mul.s' },
   { id: 'mmioEcho',    label: 'MMIO Keyboard Echo',desc: 'poll receiver, echo to transmitter' },
+  { id: 'bitmapSmile', label: 'Bitmap Smile',     desc: 'data only — open Tools → Bitmap Display' },
 ]
 
 function ExamplesDropdown() {
   const loadFromExample = useSimulator((s) => s.loadFromExample)
   const [open, setOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!open) return
     function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node
       if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
+        buttonRef.current && !buttonRef.current.contains(target) &&
+        menuRef.current && !menuRef.current.contains(target)
       ) {
         setOpen(false)
       }
@@ -81,9 +86,20 @@ function ExamplesDropdown() {
     }
   }, [open])
 
+  // Phase 3 follow-up: portal the dropdown to document.body so it
+  // escapes the Shell's outer overflow:hidden. Re-measure the
+  // button's position whenever the menu opens so the portal lands
+  // directly under the trigger.
+  useLayoutEffect(() => {
+    if (!open || !buttonRef.current) return
+    const rect = buttonRef.current.getBoundingClientRect()
+    setPos({ left: rect.left, top: rect.bottom + 4 })
+  }, [open])
+
   return (
-    <div ref={containerRef} className="relative">
+    <>
       <button
+        ref={buttonRef}
         type="button"
         aria-haspopup="menu"
         aria-expanded={open}
@@ -100,11 +116,13 @@ function ExamplesDropdown() {
         <span aria-hidden="true" className="text-[10px] text-ink-3">▾</span>
       </button>
 
-      {open && (
+      {open && pos && createPortal(
         <div
+          ref={menuRef}
           role="menu"
           aria-label="Load example program"
-          className="absolute left-0 top-full z-40 mt-1 min-w-[18rem] max-h-[60vh] overflow-y-auto rounded-md border border-divider bg-surface-elev py-1 shadow-lg"
+          style={{ position: 'fixed', left: pos.left, top: pos.top }}
+          className="z-[60] min-w-[18rem] max-h-[60vh] overflow-y-auto rounded-md border border-divider bg-surface-elev py-1 shadow-lg"
         >
           {EXAMPLES.map((example) => (
             <button
@@ -123,9 +141,10 @@ function ExamplesDropdown() {
               </div>
             </button>
           ))}
-        </div>
+        </div>,
+        document.body,
       )}
-    </div>
+    </>
   )
 }
 

--- a/src/ui/ToolsPanel.tsx
+++ b/src/ui/ToolsPanel.tsx
@@ -1,0 +1,81 @@
+import { useSimulator } from '@/hooks/useSimulator.ts'
+
+// Phase 3 follow-up: wires the rail's Tools icon. Mirrors the
+// Tools menu bar entries as a clickable list so users who keep the
+// rail expanded can launch tools without going up to the menu.
+
+interface ToolEntry {
+  label: string
+  description: string
+  onClick: () => void
+}
+
+export function ToolsPanel() {
+  const openTool          = useSimulator((s) => s.openTool)
+  const openPlaceholder   = useSimulator((s) => s.openPlaceholderTool)
+  const toggleMagnifier   = useSimulator((s) => s.toggleScreenMagnifier)
+
+  const real: ToolEntry[] = [
+    { label: 'Instruction Counter',           description: 'Static + runtime mnemonic histogram', onClick: () => openTool('instructionCounter') },
+    { label: 'Bitmap Display',                description: 'Treats memory as a 2D pixel grid',     onClick: () => openTool('bitmap') },
+    { label: 'Keyboard / Display MMIO',       description: 'Memory-mapped I/O at 0xffff0000',     onClick: () => openTool('mmio') },
+    { label: 'Floating-Point Representation', description: 'IEEE 754 bit-level editor',            onClick: () => openTool('fpRepr') },
+    { label: 'Memory Reference Visualization',description: 'Top-50 access bar chart',              onClick: () => openTool('memRef') },
+    { label: 'Screen Magnifier',              description: 'Floating loupe for projector demos',   onClick: toggleMagnifier },
+  ]
+
+  const placeholders: ToolEntry[] = [
+    { label: 'Data Cache Simulator',  description: 'v2.0', onClick: () => openPlaceholder('Data Cache Simulator') },
+    { label: 'MIPS X-Ray',            description: 'v2.0', onClick: () => openPlaceholder('MIPS X-Ray') },
+    { label: 'BHT Simulator',         description: 'v2.0', onClick: () => openPlaceholder('BHT Simulator') },
+    { label: 'Digital Lab Sim',       description: 'v2.0', onClick: () => openPlaceholder('Digital Lab Sim') },
+    { label: 'Scavenger Hunt',        description: 'v2.0', onClick: () => openPlaceholder('Scavenger Hunt') },
+    { label: 'Mars Bot',              description: 'v2.0', onClick: () => openPlaceholder('Mars Bot') },
+  ]
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div
+        className="flex h-7 flex-none items-center justify-between border-b border-divider px-3 font-mono text-[10px] uppercase text-ink-3"
+        style={{ letterSpacing: '0.06em' }}
+      >
+        <span className="text-ink-2">Tools</span>
+        <span className="text-ink-3">{real.length} + {placeholders.length}</span>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <Section title="Available" entries={real} />
+        <Section title="Coming in v2.0" entries={placeholders} muted />
+      </div>
+    </div>
+  )
+}
+
+function Section({ title, entries, muted }: { title: string; entries: ToolEntry[]; muted?: boolean }) {
+  return (
+    <section>
+      <header
+        className="sticky top-0 z-10 border-b border-divider/60 bg-surface-1 px-3 py-1 font-mono text-[10px] uppercase text-ink-3"
+        style={{ letterSpacing: '0.06em' }}
+      >
+        {title}
+      </header>
+      <ul className="divide-y divide-divider/40">
+        {entries.map((entry) => (
+          <li key={entry.label}>
+            <button
+              type="button"
+              onClick={entry.onClick}
+              className="block w-full px-3 py-1.5 text-left transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:bg-surface-2"
+            >
+              <div className={'text-[11px] ' + (muted ? 'text-ink-2' : 'text-ink-1')}>{entry.label}</div>
+              <div className="font-mono text-[10px] text-ink-3" style={{ letterSpacing: '0.04em' }}>
+                {entry.description}
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}


### PR DESCRIPTION
Six follow-ups against the in-browser feedback list.

1. **Console first-byte now fixed for every line.** ConsolePanel rendered each output line as its own `<pre>` block; React reconciliation against the buffer-split array dropped the first character on re-render. Replaced with a single `<pre>` containing the joined visible buffer; browsers render \n natively.

2. **Examples dropdown was clipped by the Shell's outer overflow:hidden.** Portaled the dropdown to document.body via createPortal with a position computed from the trigger button's bounding rect.

3. **Help dialog couldn't scroll on shorter viewports.** Switched from fixed h-[44rem] to height: 90vh max-h-[90vh] max-w-[95vw].

4. **LeftRail Project / Tools icons were placeholders.** Built ProjectPanel (file list with New/Open/Save) and ToolsPanel (every tool clickable with v2.0 placeholders separated). Both wire into LeftRail's existing render branch.

5. **Mobile editor was invisible.** MobileShell's main wrapper now uses relative + absolute inset-0 children so Monaco's automaticLayout measures a real height on portrait phones.

6. **Bitmap Display example.** examples/bitmapSmile.asm draws an 8x8 smile face into .data with step-by-step instructions in its header. Added to the Examples dropdown and command palette.

## Verification

- typecheck + lint + 119/119 tests + build green
- Bundle: 413 KB JS / 115 KB gzip