### PR TITLE
fix(asm): auto-align .word/.half + char literals + .align directive; simplify io.print

### DIFF
--- a/src/core/instructions.ts
+++ b/src/core/instructions.ts
@@ -25,6 +25,32 @@ function tokenizeLine(line: string, lineNum: number): Token[] {
       s = s.slice(end + 1);
       continue;
     }
+    // Phase 3 follow-up: single-quoted char literals are immediates
+    // whose value is the character's codepoint. Without this, .byte
+    // 'j' was tokenized as an ident, pass 1 counted 1 byte (default
+    // when no immediate followed) but pass 2 emitted nothing —
+    // every label after a .byte 'X' fell out of sync with the
+    // emitted memory layout. Supports the standard escape set.
+    if (s.startsWith("'")) {
+      const end = s.indexOf("'", 1);
+      if (end !== -1) {
+        const inner = s.slice(1, end);
+        let charCode: number | null = null;
+        if (inner.length === 1)        charCode = inner.charCodeAt(0);
+        else if (inner === '\\n')      charCode = 0x0a;
+        else if (inner === '\\t')      charCode = 0x09;
+        else if (inner === '\\0')      charCode = 0;
+        else if (inner === '\\r')      charCode = 0x0d;
+        else if (inner === '\\\\')     charCode = 0x5c;
+        else if (inner === "\\'")      charCode = 0x27;
+        else if (inner === '\\"')      charCode = 0x22;
+        if (charCode !== null) {
+          tokens.push({ type: 'immediate', value: String(charCode), line: lineNum });
+          s = s.slice(end + 1);
+          continue;
+        }
+      }
+    }
     if (s[0] === ',') { tokens.push({ type: 'comma', value: ',', line: lineNum }); s = s.slice(1); continue; }
     if (s[0] === '(') { tokens.push({ type: 'lparen', value: '(', line: lineNum }); s = s.slice(1); continue; }
     if (s[0] === ')') { tokens.push({ type: 'rparen', value: ')', line: lineNum }); s = s.slice(1); continue; }
@@ -103,6 +129,31 @@ export function assemble(source: string): AssembledProgram {
     const toks = tokenizeLine(lines[i] ?? '', i + 1);
     allTokens.push(toks);
 
+    // Phase 3 follow-up: auto-align dataAddr BEFORE any label on this
+    // line gets committed. Real MARS auto-aligns .word and .half
+    // (and the explicit .align N) so labels following a .byte or
+    // .asciiz still land on natural boundaries. The pre-scan looks
+    // at the directives on this line and bumps dataAddr UP first.
+    // Only effective when we were already in .data at line start;
+    // a .data switch inside this line is handled normally below.
+    if (!inText) {
+      for (const t of toks) {
+        if (t.type !== 'directive') continue;
+        if (t.value === '.word' || t.value === '.float') {
+          dataAddr = (dataAddr + 3) & ~3
+          break
+        }
+        if (t.value === '.double') {
+          dataAddr = (dataAddr + 7) & ~7
+          break
+        }
+        if (t.value === '.half') {
+          dataAddr = (dataAddr + 1) & ~1
+          break
+        }
+      }
+    }
+
     let mnemonicSeen = false;
 
     for (let j = 0; j < toks.length; j++) {
@@ -151,6 +202,19 @@ export function assemble(source: string): AssembledProgram {
           } else if (tok.value === '.space') {
             const sz = toks[j + 1];
             if (sz) dataAddr += parseImm(sz.value);
+          } else if (tok.value === '.align') {
+            // .align N → align dataAddr UP to next 2^N boundary.
+            // No-op when already aligned. N=0 explicitly disables
+            // alignment for the next directive in real MARS, but
+            // we do not implement that nuance.
+            const sz = toks[j + 1];
+            if (sz?.type === 'immediate') {
+              const n = parseImm(sz.value);
+              const boundary = 1 << n;
+              if (boundary > 1) {
+                dataAddr = (dataAddr + boundary - 1) & ~(boundary - 1);
+              }
+            }
           }
         }
       } else if (tok.type === 'ident' && !mnemonicSeen && inText) {
@@ -190,6 +254,28 @@ export function assemble(source: string): AssembledProgram {
   for (let i = 0; i < lines.length; i++) {
     const toks = allTokens[i]!;
     let j = 0;
+
+    // Phase 3 follow-up: mirror pass 1's auto-alignment by emitting
+    // pad bytes BEFORE any .word/.half/.float/.double directive on
+    // this line. Keeps dataBytes.length in sync with the addresses
+    // pass 1 baked into the labels map.
+    if (!inText) {
+      for (const t of toks) {
+        if (t.type !== 'directive') continue;
+        if (t.value === '.word' || t.value === '.float') {
+          while (dataBytes.length & 3) dataBytes.push(0);
+          break;
+        }
+        if (t.value === '.double') {
+          while (dataBytes.length & 7) dataBytes.push(0);
+          break;
+        }
+        if (t.value === '.half') {
+          while (dataBytes.length & 1) dataBytes.push(0);
+          break;
+        }
+      }
+    }
 
     while (j < toks.length) {
       const tok = toks[j]!;
@@ -263,6 +349,18 @@ export function assemble(source: string): AssembledProgram {
             if (sz) {
               const n = parseImm(sz.value);
               for (let k = 0; k < n; k++) dataBytes.push(0);
+            }
+            j += 2; continue;
+          }
+          if (dir === '.align') {
+            // .align N → pad dataBytes UP to next 2^N boundary.
+            const sz = toks[j + 1];
+            if (sz?.type === 'immediate') {
+              const n = parseImm(sz.value);
+              const boundary = 1 << n;
+              if (boundary > 1) {
+                while (dataBytes.length % boundary !== 0) dataBytes.push(0);
+              }
             }
             j += 2; continue;
           }

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -832,20 +832,19 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
     if (_sim) return _sim
     _sim = new Simulator({
       print: (s) => {
-        // Defer the state update through queueMicrotask so React commits
-        // the previous render before the next state lands. Without this,
-        // the FIRST print of a program can land in the same microtask
-        // as the simulator's status flip to 'running', and the bottom
-        // panel never paints the freshly-mounted ConsolePanel before
-        // the second update arrives, dropping the first character.
-        queueMicrotask(() => {
-          set((state) => {
-            const nextBuffer = state.consoleBuffer + s
-            return {
-              consoleBuffer: nextBuffer,
-              consoleOutput: nextBuffer.split('\n'),
-            }
-          })
+        // Direct set with the functional updater. The earlier
+        // queueMicrotask defer was speculative and turned out to
+        // interact badly with multi-print sequences (some browsers
+        // dropped the first character of the queued state update
+        // when React's reconciliation ran during the microtask
+        // flush). The always-mount fix in BottomPanel + the single-
+        // <pre> render in ConsolePanel are the real fixes.
+        set((state) => {
+          const nextBuffer = state.consoleBuffer + s
+          return {
+            consoleBuffer: nextBuffer,
+            consoleOutput: nextBuffer.split('\n'),
+          }
         })
       },
       // syscall 5 — readInt. Suspends the simulator behind a Promise

--- a/src/tests/dataAlignment.test.ts
+++ b/src/tests/dataAlignment.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import { assemble } from '../core/instructions'
+import { Simulator } from '../core/simulator'
+import type { SyscallIO } from '../core/syscalls'
+
+// Phase 3 follow-up: real MARS auto-aligns .word and .half so labels
+// declared after a .byte / .asciiz still land on natural boundaries.
+// These tests pin that behavior so a regression in the assembler's
+// alignment surfaces here instead of as an "Unaligned word read"
+// runtime error.
+
+function makeIO(printed: string[]): SyscallIO {
+  return {
+    print: (s) => { printed.push(s) },
+    readInt: () => Promise.resolve(0),
+    readString: () => Promise.resolve(''),
+    exit: () => {},
+  }
+}
+
+async function runAndPrint(source: string): Promise<string> {
+  const program = assemble(source)
+  expect(program.errors).toEqual([])
+  const printed: string[] = []
+  const sim = new Simulator(makeIO(printed))
+  sim.load(program)
+  await sim.run()
+  return printed.join('')
+}
+
+describe('Data alignment (Phase 3 follow-up)', () => {
+  it('.word lands on a 4-byte boundary even after a .byte', async () => {
+    // myChar lives at 0x10010005 (single byte). Without auto-align
+    // the .word that follows would land at 0x10010006 (unaligned).
+    // This program loads and prints n1 — if alignment is broken,
+    // the lw throws and the test fails with the assembler error.
+    const out = await runAndPrint(`
+      .data
+      myChar: .byte 'j'
+      n1:     .word 42
+      .text
+      main:
+        la      $t0, n1
+        lw      $a0, 0($t0)
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(out).toBe('42')
+  })
+
+  it('multiple .word entries each land on 4-byte boundaries', async () => {
+    const out = await runAndPrint(`
+      .data
+      pad:    .byte 'x'
+      a:      .word 100
+      b:      .word 200
+      .text
+      main:
+        la      $t0, a
+        lw      $a0, 0($t0)
+        li      $v0, 1
+        syscall
+        la      $t0, b
+        lw      $a0, 0($t0)
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(out).toBe('100200')
+  })
+
+  it('.half lands on a 2-byte boundary even after a .byte', async () => {
+    const out = await runAndPrint(`
+      .data
+      one_byte: .byte 1
+      h:        .half 9999
+      .text
+      main:
+        la      $t0, h
+        lh      $a0, 0($t0)
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(out).toBe('9999')
+  })
+
+  it("char-literal .byte 'X' emits the codepoint", async () => {
+    const out = await runAndPrint(`
+      .data
+      ch:     .byte 'A'
+      .text
+      main:
+        la      $t0, ch
+        lb      $a0, 0($t0)
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(out).toBe('65')   // 'A' = 65
+  })
+
+  it('common escapes inside char literals decode correctly', async () => {
+    const out = await runAndPrint(`
+      .data
+      nl:     .byte '\\n'
+      .text
+      main:
+        la      $t0, nl
+        lb      $a0, 0($t0)
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(out).toBe('10')   // \\n = 10
+  })
+
+  it('.align N forces alignment to 2^N', async () => {
+    // Without .align 3, n1 would be at offset 1 (unaligned).
+    // With .align 3, n1 lands at offset 8 (aligned to 8 bytes).
+    const program = assemble(`
+      .data
+      pad:    .byte 1
+      .align  3
+      n1:     .word 1
+    `)
+    expect(program.errors).toEqual([])
+    const n1Addr = program.labels.get('n1')
+    expect(n1Addr).toBeDefined()
+    expect((n1Addr ?? 0) & 7).toBe(0)
+  })
+})


### PR DESCRIPTION
Three real bugs surfaced by the user's tutorial program (mipsTCode.asm).

## 1. Char literal lexer
`.byte 'j'` was tokenized as an ident, so pass 1 counted 1 byte (the `count||1` fallback) but pass 2 emitted nothing. Every label after a `.byte 'X'` fell out of sync. Fixed: tokenizeLine now recognises single-quoted char literals as immediates with the codepoint (and the common escapes).

## 2. Auto-alignment for .word and .half
Real MARS aligns `.word` to 4 and `.half` to 2 so labels declared after a `.byte` or `.asciiz` still land on natural boundaries. Both passes now pre-scan each line for a `.word` / `.half` / `.float` / `.double` directive and bump dataAddr / pad dataBytes UP to the boundary BEFORE any label on the line is committed. New `.align N` directive aligns to 2^N.

Root cause of the user's **'Unaligned word read at 0x6 (pc=0x00400004)'** runtime error.

## 3. io.print simplified
Removed the `queueMicrotask` defer (SA-1 speculative hardening that interacted badly with multi-print sequences). The always-mount fix in BottomPanel + the single-`<pre>` render in ConsolePanel are the real fixes for the original first-byte bug.

## Verification

- typecheck + lint + 125/125 tests + build green
- 6 new tests in dataAlignment.test.ts (.word align, multi-word align, .half align, .align N, char literal, char literal escape)