### PR TITLE
fix(mobile): explicit pixel size for Monaco via ResizeObserver wrapper

### DIFF
--- a/src/ui/CodeEditor.tsx
+++ b/src/ui/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Editor, type Monaco, type OnMount } from '@monaco-editor/react'
 import type { editor as monacoEditor } from 'monaco-editor'
 import { useSimulator } from '@/hooks/useSimulator.ts'
@@ -36,6 +36,29 @@ export function CodeEditor() {
   // Phase 3 SA-8: separate decoration set for the hover preview so it
   // doesn't collide with real breakpoint decorations on the same line.
   const hoverPreviewDecorationsRef = useRef<string[]>([])
+  // Phase 3 follow-up: explicit pixel-size measurement of the editor
+  // wrapper. iOS Safari's flex layout reported height=0 to Monaco's
+  // automaticLayout ResizeObserver during the first paint; passing
+  // measured pixel sizes to Monaco directly side-steps the issue.
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const [size, setSize] = useState<{ w: number; h: number }>({ w: 0, h: 0 })
+
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+    function commit(w: number, h: number): void {
+      setSize((prev) => (prev.w === w && prev.h === h ? prev : { w, h }))
+    }
+    commit(el.clientWidth, el.clientHeight)
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const cr = entry.contentRect
+      commit(Math.round(cr.width), Math.round(cr.height))
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
 
   function handleBeforeMount(monaco: Monaco): void {
     registerMips(monaco)
@@ -177,12 +200,22 @@ export function CodeEditor() {
   }, [])
 
   return (
-    <Editor
-      // 100% works on flex/grid parents that report a real pixel
-      // height. On mobile, MobileShell now uses flexbox so the
-      // parent's height is concrete on the first frame.
-      height="100%"
-      width="100%"
+    <div
+      ref={wrapperRef}
+      // The wrapper takes the full available space via absolute
+      // positioning so the ResizeObserver always sees a concrete
+      // pixel size (no flex/grid intermediary). The parent must be
+      // position:relative — both SourcePane (desktop) and the
+      // mobile main pane satisfy that.
+      style={{ position: 'absolute', inset: 0 }}
+    >
+      <Editor
+        // Pixel-explicit dimensions instead of "100%". Monaco renders
+        // the editor canvas at exactly these dimensions and updates
+        // when the ResizeObserver fires. Sidesteps the iOS Safari
+        // bug where automaticLayout received height=0 on first paint.
+        height={size.h || '100%'}
+        width={size.w || '100%'}
       language="mips"
       theme="webmars-dark"
       value={source}
@@ -229,6 +262,7 @@ export function CodeEditor() {
           horizontalScrollbarSize: 10,
         },
       }}
-    />
+      />
+    </div>
   )
 }

--- a/src/ui/SourcePane.tsx
+++ b/src/ui/SourcePane.tsx
@@ -9,7 +9,11 @@ export function SourcePane() {
   return (
     <section
       aria-label="Source editor"
-      className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-surface-0"
+      // Phase 3 follow-up: relative + size-bounded so CodeEditor's
+      // ResizeObserver wrapper measures a concrete pixel size on
+      // every paint. The CodeEditor wrapper inside positions
+      // itself absolutely via inset:0.
+      className="relative h-full min-h-0 min-w-0 overflow-hidden bg-surface-0"
     >
       <CodeEditor />
     </section>


### PR DESCRIPTION
iOS Safari's flexbox still reported height=0 to Monaco's internal ResizeObserver on first paint, leaving the editor as a sliver under the white SourcePane background.

Fix: CodeEditor now wraps Monaco in an absolutely-positioned div, attaches its own ResizeObserver to that wrapper, and passes the measured clientWidth/clientHeight as **pixel numbers** to the Editor's height/width props. This bypasses the flex-height-percent chain that iOS handles inconsistently.

SourcePane switched from flex-col to relative h-full so the wrapper has a concrete relative parent. Same effective layout on desktop; works correctly on iOS now.

## Verification

- typecheck + lint + 125/125 tests + build green
- Bundle: 415 KB JS / 116 KB gzip