### PR TITLE
feat: phase 4 — landing page at /, IDE at /app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ WebMARS is a functional re-implementation of the core features of the original [
 
 The project is built in TypeScript with React, Vite, and Tailwind CSS, and runs entirely in the browser.
 
+## Live demo
+
+Visit **[webmarsimulator.com](https://www.webmarsimulator.com/)** for the project landing page, or jump straight to the IDE at **[webmarsimulator.com/app](https://www.webmarsimulator.com/app)**.
+
 ## Status
 
 v1.1.0. Every PRD must-have and stretch goal shipped, plus the Phase 3 bug-fix sweep: missing pseudo-instructions, console first-byte fix, resizable panels, in-app help dialog, breakpoint hover preview, full Tools menu (Bitmap Display, MMIO simulator, IEEE 754 representation, memory reference visualization, screen magnifier), reworked mobile shell with tabbed layout. 119 tests passing.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,24 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WebMARS</title>
+
+    <!-- SEO -->
+    <title>WebMARS — Modern MIPS Simulator in your browser</title>
+    <meta name="description" content="A complete MIPS development environment running entirely in your browser. Assembler, simulator, debugger, FPU, and visual tools. Free and open source. No install required." />
+    <meta name="theme-color" content="#22D3EE" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="WebMARS — MIPS in your browser" />
+    <meta property="og:description" content="A modern, browser-based MIPS simulator with full IDE, debugger, and visual tools." />
+    <meta property="og:image" content="/og-image.png" />
+    <meta property="og:url" content="https://www.webmarsimulator.com/" />
+    <meta property="og:type" content="website" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="WebMARS — MIPS in your browser" />
+    <meta name="twitter:description" content="A modern, browser-based MIPS simulator with full IDE, debugger, and visual tools." />
+    <meta name="twitter:image" content="/og-image.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -10,18 +10,16 @@
     <meta name="description" content="A complete MIPS development environment running entirely in your browser. Assembler, simulator, debugger, FPU, and visual tools. Free and open source. No install required." />
     <meta name="theme-color" content="#22D3EE" />
 
-    <!-- Open Graph -->
+    <!-- Open Graph (image deferred — no captured screenshot yet) -->
     <meta property="og:title" content="WebMARS — MIPS in your browser" />
     <meta property="og:description" content="A modern, browser-based MIPS simulator with full IDE, debugger, and visual tools." />
-    <meta property="og:image" content="/og-image.png" />
     <meta property="og:url" content="https://www.webmarsimulator.com/" />
     <meta property="og:type" content="website" />
 
     <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="WebMARS — MIPS in your browser" />
     <meta name="twitter:description" content="A modern, browser-based MIPS simulator with full IDE, debugger, and visual tools." />
-    <meta name="twitter:image" content="/og-image.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.webmarsimulator.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://www.webmarsimulator.com/</loc><changefreq>monthly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://www.webmarsimulator.com/app</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
+</urlset>

--- a/src/landing/Features.tsx
+++ b/src/landing/Features.tsx
@@ -1,0 +1,131 @@
+// Phase 4 SA-5: 6 honest features in a 3-column grid. Inline SVG
+// icons (no lucide-react dep) — minimal stroke icons that match
+// the accent color on hover.
+
+interface Feature {
+  title: string
+  body: string
+  icon: React.ReactNode
+}
+
+const FEATURES: ReadonlyArray<Feature> = [
+  {
+    title: 'Modern MIPS32 + FPU + Cop0',
+    body:
+      '50+ instructions across arithmetic, logic, branches, jumps, load/store, FPU single-precision, and trap families. Pseudo-instructions like blt, bgt, abs, sge, and move expand to the right encodings.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+      </svg>
+    ),
+  },
+  {
+    title: 'A real debugger, not a runner',
+    body:
+      'Set breakpoints with one gutter click. Step forward, step backward, watch registers update in real time. Run-to-cursor and a 1–500 instr/s speed slider let you see exactly what your code does.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="m8 2 1.88 1.88" />
+        <path d="M14.12 3.88 16 2" />
+        <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
+        <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" />
+        <path d="M12 20v-9" />
+        <path d="M6.53 9C4.6 8.8 3 7.1 3 5" />
+        <path d="M6 13H2" />
+        <path d="M3 21c0-2.1 1.7-3.9 3.8-4" />
+        <path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" />
+        <path d="M22 13h-4" />
+        <path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Built-in tools',
+    body:
+      'Bitmap display for graphics programs, keyboard / display MMIO for interactive games, IEEE 754 representation editor, instruction counter, memory reference visualization, and a screen magnifier. All in the Tools menu.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Files that work',
+    body:
+      'Open and save .asm files directly from your computer. Multi-file tabs with drag-to-reorder. Examples menu with 8 starter programs. Recent files, find / replace, syntax highlighting, hover docs. Powered by Monaco — the same editor in VS Code.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Zero install',
+    body:
+      'WebMARS runs entirely in modern browsers. No Java, no JVM, no downloads, no admin permissions. Deploy a link, students start coding.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+        <path d="M2 12h20" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Built for the classroom',
+    body:
+      'Modeled after the curriculum-standard MARS simulator from Patterson & Hennessy. 125+ tests verify correctness against real MARS behavior on the v1.0 instruction set. MIT licensed, source on GitHub.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z" />
+        <path d="M22 10v6" />
+        <path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5" />
+      </svg>
+    ),
+  },
+]
+
+export function Features() {
+  return (
+    <section id="features" aria-labelledby="features-heading" className="py-24 md:py-32">
+      <div className="mx-auto max-w-7xl px-6">
+        {/* Header */}
+        <div className="max-w-3xl">
+          <span className="mono text-[13px] font-medium uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.1em' }}>
+            Everything you need
+          </span>
+          <h2 id="features-heading" className="mt-4 text-4xl font-bold md:text-5xl" style={{ color: 'var(--l-ink-1)' }}>
+            A complete MIPS development toolkit, in one tab.
+          </h2>
+          <p className="mt-4 text-lg" style={{ color: 'var(--l-ink-2)' }}>
+            From writing your first instruction to debugging cache behavior, WebMARS handles the entire learning journey without leaving the browser.
+          </p>
+        </div>
+
+        {/* Grid */}
+        <div className="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {FEATURES.map((f) => (
+            <article
+              key={f.title}
+              className="group flex flex-col rounded-2xl border bg-white p-8 transition-all hover:-translate-y-1"
+              style={{ borderColor: 'var(--l-border)', minHeight: 280 }}
+            >
+              <div
+                className="flex size-12 items-center justify-center rounded-xl transition-colors"
+                style={{ background: 'var(--l-accent-soft)', color: 'var(--l-accent)' }}
+              >
+                <span className="size-6 block">{f.icon}</span>
+              </div>
+              <h3 className="mt-6 text-xl font-bold" style={{ color: 'var(--l-ink-1)' }}>
+                {f.title}
+              </h3>
+              <p className="mt-3 text-[15px] leading-[1.6]" style={{ color: 'var(--l-ink-2)' }}>
+                {f.body}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/landing/Features.tsx
+++ b/src/landing/Features.tsx
@@ -87,7 +87,7 @@ const FEATURES: ReadonlyArray<Feature> = [
 
 export function Features() {
   return (
-    <section id="features" aria-labelledby="features-heading" className="py-24 md:py-32">
+    <section id="features" aria-labelledby="features-heading" className="landing-reveal py-24 md:py-32">
       <div className="mx-auto max-w-7xl px-6">
         {/* Header */}
         <div className="max-w-3xl">

--- a/src/landing/FinalCTA.tsx
+++ b/src/landing/FinalCTA.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { navigate } from '@/lib/router.ts'
+import { REPO_URL, ISSUES_URL } from '@/lib/constants.ts'
+
+// Phase 4 SA-9: closing section. Gradient background with a white
+// CTA card, copy-to-clipboard helper for the live URL, and three
+// real secondary links underneath.
+
+const PRD_URL = `${REPO_URL}/blob/main/docs/PRD.md`
+const APP_URL = 'https://www.webmarsimulator.com/app'
+
+export function FinalCTA() {
+  const [copied, setCopied] = useState(false)
+
+  function copyUrl(): void {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return
+    void navigator.clipboard.writeText(APP_URL).then(() => {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  return (
+    <section
+      aria-labelledby="cta-heading"
+      className="py-32"
+      style={{ background: 'linear-gradient(135deg, var(--l-accent) 0%, var(--l-accent-dark) 100%)' }}
+    >
+      <div className="mx-auto max-w-4xl px-6 text-center">
+        <h2 id="cta-heading" className="text-4xl font-bold md:text-5xl" style={{ color: 'white' }}>
+          Ready to write some MIPS?
+        </h2>
+        <p className="mt-4 text-lg" style={{ color: 'rgba(255,255,255,0.85)' }}>
+          Open WebMARS in your browser. No download, no account, no friction. Type your first instruction in 10 seconds.
+        </p>
+
+        {/* CTA card */}
+        <div
+          className="mx-auto mt-8 flex w-full max-w-[600px] flex-col gap-4 rounded-2xl p-10 text-left"
+          style={{ background: 'white', boxShadow: 'var(--l-shadow-xl)' }}
+        >
+          <h3 className="text-xl font-bold" style={{ color: 'var(--l-ink-1)' }}>
+            Start at the URL.
+          </h3>
+
+          <div className="flex items-center gap-2 rounded-lg border bg-[var(--l-bg-alt)] px-3 py-2" style={{ borderColor: 'var(--l-border)' }}>
+            <span className="mono flex-1 truncate text-[13px]" style={{ color: 'var(--l-accent)' }}>
+              {APP_URL}
+            </span>
+            <button
+              type="button"
+              onClick={copyUrl}
+              aria-label={copied ? 'URL copied' : 'Copy URL'}
+              className="rounded px-2 py-1 text-[12px] font-medium transition-colors hover:bg-white"
+              style={{ color: 'var(--l-ink-2)' }}
+            >
+              {copied ? 'Copied ✓' : 'Copy'}
+            </button>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => navigate('/app')}
+            className="mt-2 w-full rounded-[10px] px-8 text-base font-semibold text-white transition-transform hover:-translate-y-0.5"
+            style={{ background: 'var(--l-accent)', height: 56 }}
+          >
+            Open the editor →
+          </button>
+
+          <p className="text-[12px]" style={{ color: 'var(--l-ink-3)' }}>
+            Works in Chrome, Edge, Firefox, Safari. Recommended: Chromium-based browsers for File System Access API support.
+          </p>
+
+          <hr style={{ borderColor: 'var(--l-border)' }} />
+
+          <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-[14px]" style={{ color: 'var(--l-ink-2)' }}>
+            <a href={REPO_URL}    target="_blank" rel="noopener noreferrer" className="transition-colors hover:[color:var(--l-accent)]">View on GitHub</a>
+            <span aria-hidden="true">·</span>
+            <a href={PRD_URL}     target="_blank" rel="noopener noreferrer" className="transition-colors hover:[color:var(--l-accent)]">Read the PRD</a>
+            <span aria-hidden="true">·</span>
+            <a href={ISSUES_URL}  target="_blank" rel="noopener noreferrer" className="transition-colors hover:[color:var(--l-accent)]">Report a bug</a>
+          </div>
+        </div>
+
+        <p className="mt-6 text-[14px]" style={{ color: 'rgba(255,255,255,0.85)' }}>
+          WebMARS is free and open source. MIT licensed.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/src/landing/FinalCTA.tsx
+++ b/src/landing/FinalCTA.tsx
@@ -23,7 +23,7 @@ export function FinalCTA() {
   return (
     <section
       aria-labelledby="cta-heading"
-      className="py-32"
+      className="landing-reveal py-32"
       style={{ background: 'linear-gradient(135deg, var(--l-accent) 0%, var(--l-accent-dark) 100%)' }}
     >
       <div className="mx-auto max-w-4xl px-6 text-center">

--- a/src/landing/Footer.tsx
+++ b/src/landing/Footer.tsx
@@ -1,0 +1,95 @@
+import { navigate } from '@/lib/router.ts'
+import { REPO_URL } from '@/lib/constants.ts'
+
+// Phase 4 SA-10: 3-column footer with brand, project links, and
+// team credits. No fake social links, no fake forum, no fake
+// tutorials section. Only references things that genuinely exist.
+
+const PRD_URL    = `${REPO_URL}/blob/main/docs/PRD.md`
+const REPORT_URL = `${REPO_URL}/blob/main/docs/FINAL_REPORT.md`
+
+export function Footer() {
+  return (
+    <footer
+      className="pt-16 pb-12"
+      style={{ background: '#0A0D12', color: '#A8B0C0' }}
+    >
+      <div className="mx-auto grid max-w-7xl gap-12 px-6 md:grid-cols-[2fr_1.2fr_1.2fr]">
+        {/* Brand column */}
+        <div>
+          <div className="flex items-center gap-2">
+            <span aria-hidden="true" style={{ width: 12, height: 12, background: 'var(--l-accent)', borderRadius: 2 }} />
+            <span className="text-xl font-bold" style={{ color: 'white' }}>WebMARS</span>
+          </div>
+          <p className="mt-3 text-[14px]" style={{ color: '#A8B0C0' }}>
+            A modern, browser-based MIPS simulator. Built in 2026.
+          </p>
+          <p className="mt-2 text-[12px] italic" style={{ color: '#8B95A8' }}>
+            Made with TypeScript, React, Vite, Tailwind, Monaco, and Zustand.
+          </p>
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub repository"
+            className="mt-4 inline-flex size-8 items-center justify-center rounded transition-colors hover:[color:white]"
+            style={{ color: '#A8B0C0' }}
+          >
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+            </svg>
+          </a>
+        </div>
+
+        {/* Project column */}
+        <div>
+          <h3 className="mono text-[12px] font-medium uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.08em' }}>
+            Project
+          </h3>
+          <ul className="mt-4 flex flex-col gap-2 text-[14px]">
+            <li>
+              <button
+                type="button"
+                onClick={() => navigate('/app')}
+                className="transition-colors hover:[color:white]"
+                style={{ color: '#A8B0C0' }}
+              >
+                Try the editor
+              </button>
+            </li>
+            <li>
+              <a href={REPO_URL}   target="_blank" rel="noopener noreferrer" className="transition-colors hover:[color:white]" style={{ color: '#A8B0C0' }}>GitHub repository</a>
+            </li>
+            <li>
+              <a href={PRD_URL}    target="_blank" rel="noopener noreferrer" className="transition-colors hover:[color:white]" style={{ color: '#A8B0C0' }}>PRD</a>
+            </li>
+            <li>
+              <a href={REPORT_URL} target="_blank" rel="noopener noreferrer" className="transition-colors hover:[color:white]" style={{ color: '#A8B0C0' }}>Final report</a>
+            </li>
+          </ul>
+        </div>
+
+        {/* Team column */}
+        <div>
+          <h3 className="mono text-[12px] font-medium uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.08em' }}>
+            Team
+          </h3>
+          <ul className="mt-4 flex flex-col gap-2 text-[14px]" style={{ color: '#A8B0C0' }}>
+            <li>Bryan Djenabia — UI, integration, deployment</li>
+            <li>Landon Clay — Assembler and parser</li>
+            <li>Zachary Gass — Simulator and execution</li>
+          </ul>
+        </div>
+      </div>
+
+      <div
+        className="mx-auto mt-12 flex max-w-7xl flex-col gap-2 border-t px-6 pt-8 text-center text-[12px] md:flex-row md:items-center md:justify-between"
+        style={{ borderColor: 'rgba(255,255,255,0.08)', color: '#8B95A8' }}
+      >
+        <span>© 2026 Bryan Djenabia, Landon Clay, Zachary Gass.</span>
+        <span>MIT licensed.</span>
+        <span>Inspired by MARS by Pete Sanderson &amp; Kenneth Vollmar.</span>
+      </div>
+    </footer>
+  )
+}

--- a/src/landing/Hero.tsx
+++ b/src/landing/Hero.tsx
@@ -33,7 +33,7 @@ export function Hero() {
             className="mt-4 max-w-[540px] text-5xl font-bold leading-[1.1] md:text-6xl"
             style={{ color: 'var(--l-ink-1)' }}
           >
-            MIPS assembly, finally in your browser.
+            A modern MIPS simulator that runs in your browser.
           </h1>
           <p
             className="mt-6 max-w-[520px] text-lg leading-[1.5] md:text-xl"
@@ -41,8 +41,7 @@ export function Hero() {
           >
             WebMARS is a complete MIPS development environment — assembler,
             simulator, debugger, and visual tools — running entirely in your
-            browser. No Java, no install, no setup. Built by three students
-            for the next generation of computer-architecture courses.
+            browser. No Java, no install, no setup. Built by three students.
           </p>
 
           {/* CTAs */}

--- a/src/landing/Hero.tsx
+++ b/src/landing/Hero.tsx
@@ -1,0 +1,156 @@
+import { navigate } from '@/lib/router.ts'
+import { REPO_URL } from '@/lib/constants.ts'
+
+// Phase 4 SA-3 hero. 720px tall on desktop, two columns. Headline
+// copy is honest about what WebMARS is: a student-built, open-source
+// MIPS development environment that runs in the browser. No fake
+// adoption claims; trust signals reference real numbers (test count,
+// license, build duration).
+
+export function Hero() {
+  return (
+    <section
+      className="relative overflow-hidden"
+      style={{
+        // Faint memory-address grid pattern at 5% opacity. Pure
+        // SVG so we don't ship an extra image asset for the hero.
+        background:
+          'linear-gradient(0deg, var(--l-bg) 0%, var(--l-bg) 100%), ' +
+          "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='80' height='80'><path d='M 80 0 L 0 0 0 80' fill='none' stroke='%2322D3EE' stroke-width='1' opacity='0.08'/></svg>\")",
+        backgroundBlendMode: 'normal',
+      }}
+    >
+      <div className="mx-auto grid max-w-7xl items-center gap-12 px-6 py-20 md:grid-cols-[60%_40%] md:py-28 md:min-h-[720px]">
+        {/* LEFT — copy */}
+        <div className="flex flex-col">
+          <span
+            className="mono text-[13px] font-medium uppercase"
+            style={{ color: 'var(--l-accent)', letterSpacing: '0.1em' }}
+          >
+            Free · Open source · No install
+          </span>
+          <h1
+            className="mt-4 max-w-[540px] text-5xl font-bold leading-[1.1] md:text-6xl"
+            style={{ color: 'var(--l-ink-1)' }}
+          >
+            MIPS assembly, finally in your browser.
+          </h1>
+          <p
+            className="mt-6 max-w-[520px] text-lg leading-[1.5] md:text-xl"
+            style={{ color: 'var(--l-ink-2)' }}
+          >
+            WebMARS is a complete MIPS development environment — assembler,
+            simulator, debugger, and visual tools — running entirely in your
+            browser. No Java, no install, no setup. Built by three students
+            for the next generation of computer-architecture courses.
+          </p>
+
+          {/* CTAs */}
+          <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center">
+            <div className="flex flex-col">
+              <button
+                type="button"
+                onClick={() => navigate('/app')}
+                className="group flex items-center justify-center gap-2 rounded-[10px] px-8 text-base font-semibold text-white transition-all hover:-translate-y-0.5"
+                style={{
+                  background: 'var(--l-accent)',
+                  height: 56,
+                  boxShadow: '0 8px 24px rgba(34,211,238,0.25)',
+                }}
+              >
+                Open the editor
+                <span aria-hidden="true" className="transition-transform group-hover:translate-x-0.5">→</span>
+              </button>
+              <span className="mt-2 text-[13px]" style={{ color: 'var(--l-ink-3)' }}>
+                Works in any modern browser. No account needed.
+              </span>
+            </div>
+            <a
+              href={REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-2 rounded-[10px] border-2 px-8 text-base font-semibold transition-colors"
+              style={{
+                borderColor: 'var(--l-border)',
+                color: 'var(--l-ink-1)',
+                height: 56,
+              }}
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+              </svg>
+              View on GitHub
+            </a>
+          </div>
+
+          {/* Trust signals — real numbers only */}
+          <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-2 text-[14px]" style={{ color: 'var(--l-ink-2)' }}>
+            <span>100+ tests passing</span>
+            <span aria-hidden="true">·</span>
+            <span>MIT licensed</span>
+            <span aria-hidden="true">·</span>
+            <span>Built in 6 days</span>
+          </div>
+        </div>
+
+        {/* RIGHT — hero visual placeholder. SA-11 swaps this for a
+           real screenshot. The placeholder card matches the eventual
+           dimensions so layout doesn't shift. */}
+        <div className="relative">
+          <div
+            className="relative mx-auto overflow-hidden"
+            style={{
+              width: '100%',
+              maxWidth: 600,
+              aspectRatio: '5 / 4',
+              borderRadius: 16,
+              boxShadow: 'var(--l-shadow-xl)',
+              background: 'var(--l-bg-dark)',
+              transform: 'perspective(1200px) rotateY(-5deg) rotateX(2deg)',
+            }}
+          >
+            {/* Mock IDE chrome so the placeholder looks intentional */}
+            <div className="flex items-center gap-2 px-4 py-3" style={{ background: '#1a1d24' }}>
+              <span className="size-3 rounded-full" style={{ background: '#FF5F57' }} />
+              <span className="size-3 rounded-full" style={{ background: '#FEBC2E' }} />
+              <span className="size-3 rounded-full" style={{ background: '#28C840' }} />
+              <span className="ml-3 mono text-[12px]" style={{ color: '#A8B0C0' }}>hello.asm</span>
+            </div>
+            <div className="grid h-full grid-cols-[1fr_220px]">
+              <div className="p-5 mono text-[13px] leading-6" style={{ color: '#E2E5EC' }}>
+                <span style={{ color: '#7DD3FC' }}>main:</span><br/>
+                {'  '}<span style={{ color: '#22D3EE' }}>li</span> $v0, <span style={{ color: '#FFB020' }}>4</span><br/>
+                {'  '}<span style={{ color: '#22D3EE' }}>la</span> $a0, msg<br/>
+                {'  '}<span style={{ color: '#22D3EE' }}>syscall</span><br/><br/>
+                {'  '}<span style={{ color: '#22D3EE' }}>li</span> $v0, <span style={{ color: '#FFB020' }}>10</span><br/>
+                {'  '}<span style={{ color: '#22D3EE' }}>syscall</span>
+              </div>
+              <div className="border-l p-3 mono text-[11px]" style={{ borderColor: '#2A2F3A', color: '#A8B0C0' }}>
+                <div className="mb-2 uppercase text-[10px]" style={{ color: '#5A6378', letterSpacing: '0.1em' }}>Registers</div>
+                <div className="flex justify-between"><span>$zero</span><span>0x00000000</span></div>
+                <div className="flex justify-between"><span>$v0</span><span style={{ color: '#22D3EE' }}>0x00000004</span></div>
+                <div className="flex justify-between"><span>$a0</span><span>0x10010000</span></div>
+                <div className="flex justify-between"><span>$sp</span><span>0x7FFFEFFC</span></div>
+                <div className="flex justify-between"><span>PC</span><span>0x0040000C</span></div>
+              </div>
+            </div>
+          </div>
+
+          {/* Floating callouts — desktop only */}
+          <div
+            className="hidden md:block absolute -right-2 top-8 rounded-lg p-3 text-[12px] font-medium"
+            style={{ background: 'white', boxShadow: 'var(--l-shadow-md)', color: 'var(--l-ink-1)' }}
+          >
+            ↗ Live register flash
+          </div>
+          <div
+            className="hidden md:block absolute -left-2 bottom-8 rounded-lg p-3 text-[12px] font-medium"
+            style={{ background: 'white', boxShadow: 'var(--l-shadow-md)', color: 'var(--l-ink-1)' }}
+          >
+            ↙ Click gutter to set breakpoint
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/landing/Hero.tsx
+++ b/src/landing/Hero.tsx
@@ -97,7 +97,7 @@ export function Hero() {
            dimensions so layout doesn't shift. */}
         <div className="relative">
           <div
-            className="relative mx-auto overflow-hidden"
+            className="hero-visual-float relative mx-auto overflow-hidden"
             style={{
               width: '100%',
               maxWidth: 600,
@@ -105,8 +105,9 @@ export function Hero() {
               borderRadius: 16,
               boxShadow: 'var(--l-shadow-xl)',
               background: 'var(--l-bg-dark)',
-              transform: 'perspective(1200px) rotateY(-5deg) rotateX(2deg)',
             }}
+            role="img"
+            aria-label="WebMARS editor with a Hello-MIPS program loaded, register table on the right showing live values"
           >
             {/* Mock IDE chrome so the placeholder looks intentional */}
             <div className="flex items-center gap-2 px-4 py-3" style={{ background: '#1a1d24' }}>

--- a/src/landing/LandingPage.tsx
+++ b/src/landing/LandingPage.tsx
@@ -1,10 +1,16 @@
 import './tokens.css'
 import { Nav } from './Nav.tsx'
 import { Hero } from './Hero.tsx'
+import { ProofBar } from './ProofBar.tsx'
+import { Features } from './Features.tsx'
+import { Showcase } from './Showcase.tsx'
+import { Personas } from './Personas.tsx'
+import { OriginStory } from './OriginStory.tsx'
+import { FinalCTA } from './FinalCTA.tsx'
+import { Footer } from './Footer.tsx'
 
 // Phase 4 SA-2: top-level landing page. Each section lives in its
-// own file; this component just assembles them in order. Sections
-// are filled in incrementally per SA-3..SA-10.
+// own file; this component just assembles them in order.
 
 export default function LandingPage() {
   return (
@@ -12,10 +18,14 @@ export default function LandingPage() {
       <Nav />
       <main>
         <Hero />
-        {/* SA-4 ProofBar, SA-5 Features, SA-6 Showcase, SA-7
-           Personas, SA-8 OriginStory, SA-9 FinalCTA arrive here. */}
+        <ProofBar />
+        <Features />
+        <Showcase />
+        <Personas />
+        <OriginStory />
+        <FinalCTA />
       </main>
-      {/* SA-10 Footer. */}
+      <Footer />
     </div>
   )
 }

--- a/src/landing/LandingPage.tsx
+++ b/src/landing/LandingPage.tsx
@@ -1,0 +1,28 @@
+import './tokens.css'
+import { navigate } from '@/lib/router'
+
+// Phase 4 SA-1 placeholder. SA-2 expands this into a multi-section
+// page; for now it confirms the routing wiring works end-to-end.
+
+export default function LandingPage() {
+  return (
+    <div className="landing min-h-dvh">
+      <main className="mx-auto flex min-h-dvh max-w-3xl flex-col items-center justify-center gap-6 px-6 py-16 text-center">
+        <h1 className="text-5xl font-bold" style={{ color: 'var(--l-ink-1)' }}>
+          WebMARS
+        </h1>
+        <p className="text-lg" style={{ color: 'var(--l-ink-2)' }}>
+          Modern, browser-based MIPS simulator. Real landing page lands in SA-2.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate('/app')}
+          className="rounded-lg px-6 py-3 text-base font-semibold text-white"
+          style={{ background: 'var(--l-accent)' }}
+        >
+          Open the editor →
+        </button>
+      </main>
+    </div>
+  )
+}

--- a/src/landing/LandingPage.tsx
+++ b/src/landing/LandingPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import './tokens.css'
 import { Nav } from './Nav.tsx'
 import { Hero } from './Hero.tsx'
@@ -13,10 +14,34 @@ import { Footer } from './Footer.tsx'
 // own file; this component just assembles them in order.
 
 export default function LandingPage() {
+  // Phase 4 SA-12: scroll-triggered reveal. Every element with the
+  // .landing-reveal class fades + slides up 24px as it enters the
+  // viewport. Each is unobserved after firing so animations only
+  // play once. Honors prefers-reduced-motion via the CSS rule that
+  // overrides the .landing-reveal opacity / transform.
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('landing-revealed')
+            observer.unobserve(entry.target)
+          }
+        }
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -60px 0px' },
+    )
+    document.querySelectorAll('.landing .landing-reveal').forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [])
+
   return (
     <div className="landing">
+      {/* Skip link — visible only on focus. SA-12 a11y polish. */}
+      <a href="#landing-main" className="skip-link">Skip to main content</a>
       <Nav />
-      <main>
+      <main id="landing-main" tabIndex={-1}>
         <Hero />
         <ProofBar />
         <Features />

--- a/src/landing/LandingPage.tsx
+++ b/src/landing/LandingPage.tsx
@@ -1,28 +1,21 @@
 import './tokens.css'
-import { navigate } from '@/lib/router'
+import { Nav } from './Nav.tsx'
+import { Hero } from './Hero.tsx'
 
-// Phase 4 SA-1 placeholder. SA-2 expands this into a multi-section
-// page; for now it confirms the routing wiring works end-to-end.
+// Phase 4 SA-2: top-level landing page. Each section lives in its
+// own file; this component just assembles them in order. Sections
+// are filled in incrementally per SA-3..SA-10.
 
 export default function LandingPage() {
   return (
-    <div className="landing min-h-dvh">
-      <main className="mx-auto flex min-h-dvh max-w-3xl flex-col items-center justify-center gap-6 px-6 py-16 text-center">
-        <h1 className="text-5xl font-bold" style={{ color: 'var(--l-ink-1)' }}>
-          WebMARS
-        </h1>
-        <p className="text-lg" style={{ color: 'var(--l-ink-2)' }}>
-          Modern, browser-based MIPS simulator. Real landing page lands in SA-2.
-        </p>
-        <button
-          type="button"
-          onClick={() => navigate('/app')}
-          className="rounded-lg px-6 py-3 text-base font-semibold text-white"
-          style={{ background: 'var(--l-accent)' }}
-        >
-          Open the editor →
-        </button>
+    <div className="landing">
+      <Nav />
+      <main>
+        <Hero />
+        {/* SA-4 ProofBar, SA-5 Features, SA-6 Showcase, SA-7
+           Personas, SA-8 OriginStory, SA-9 FinalCTA arrive here. */}
       </main>
+      {/* SA-10 Footer. */}
     </div>
   )
 }

--- a/src/landing/Nav.tsx
+++ b/src/landing/Nav.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react'
+import { navigate } from '@/lib/router.ts'
+import { REPO_URL } from '@/lib/constants.ts'
+
+// Phase 4 SA-3 nav bar. 72px tall, sticky. Translucent + 1px bottom
+// border once the user has scrolled past 80px so the brand area
+// doesn't collide with hero text. Mobile collapses the center
+// anchors and shows a hamburger instead.
+
+const NAV_LINKS = [
+  { label: 'Features',    href: '#features' },
+  { label: 'How it works',href: '#showcase' },
+  { label: "Who it's for", href: '#personas' },
+  { label: 'The team',    href: '#team' },
+] as const
+
+export function Nav() {
+  const [scrolled, setScrolled] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
+
+  useEffect(() => {
+    function onScroll(): void {
+      setScrolled(window.scrollY > 80)
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  function scrollToTop(): void {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  return (
+    <header
+      className="sticky top-0 z-30 transition-colors"
+      style={{
+        background: scrolled ? 'rgba(255,255,255,0.92)' : 'transparent',
+        borderBottom: scrolled ? '1px solid var(--l-border)' : '1px solid transparent',
+        backdropFilter: scrolled ? 'saturate(140%) blur(8px)' : undefined,
+      }}
+    >
+      <div className="mx-auto flex h-[72px] max-w-7xl items-center justify-between px-6">
+        {/* Brand */}
+        <button
+          type="button"
+          onClick={scrollToTop}
+          className="flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--l-accent)]"
+          aria-label="WebMARS — back to top"
+        >
+          <span aria-hidden="true" style={{ width: 12, height: 12, background: 'var(--l-accent)', borderRadius: 2 }} />
+          <span className="text-xl font-bold" style={{ color: 'var(--l-ink-1)' }}>WebMARS</span>
+        </button>
+
+        {/* Center anchors — desktop only */}
+        <nav aria-label="Sections" className="hidden md:flex items-center gap-8 text-[15px] font-medium" style={{ color: 'var(--l-ink-2)' }}>
+          {NAV_LINKS.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className="transition-colors hover:[color:var(--l-ink-1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--l-accent)] rounded"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+
+        {/* Right side */}
+        <div className="hidden md:flex items-center gap-6">
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[15px] font-medium transition-colors hover:[color:var(--l-ink-1)]"
+            style={{ color: 'var(--l-ink-2)' }}
+          >
+            GitHub
+          </a>
+          <button
+            type="button"
+            onClick={() => navigate('/app')}
+            className="rounded-[10px] px-5 text-[15px] font-semibold text-white transition-transform hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--l-accent)]"
+            style={{ background: 'var(--l-accent)', height: 40 }}
+          >
+            Try the editor
+          </button>
+        </div>
+
+        {/* Mobile hamburger */}
+        <button
+          type="button"
+          aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={mobileOpen}
+          onClick={() => setMobileOpen((v) => !v)}
+          className="md:hidden flex size-10 items-center justify-center rounded-md text-[var(--l-ink-1)] hover:bg-[var(--l-bg-alt)]"
+        >
+          <span aria-hidden="true" className="text-2xl">{mobileOpen ? '✕' : '☰'}</span>
+        </button>
+      </div>
+
+      {/* Mobile overlay */}
+      {mobileOpen && (
+        <nav
+          aria-label="Mobile navigation"
+          className="md:hidden absolute left-0 top-[72px] w-full border-t"
+          style={{ background: 'var(--l-bg)', borderColor: 'var(--l-border)' }}
+        >
+          <ul className="flex flex-col px-6 py-4 text-base">
+            {NAV_LINKS.map((link) => (
+              <li key={link.href}>
+                <a
+                  href={link.href}
+                  onClick={() => setMobileOpen(false)}
+                  className="block py-3"
+                  style={{ color: 'var(--l-ink-1)' }}
+                >
+                  {link.label}
+                </a>
+              </li>
+            ))}
+            <li>
+              <a
+                href={REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setMobileOpen(false)}
+                className="block py-3"
+                style={{ color: 'var(--l-ink-1)' }}
+              >
+                GitHub
+              </a>
+            </li>
+            <li className="pt-2">
+              <button
+                type="button"
+                onClick={() => { setMobileOpen(false); navigate('/app') }}
+                className="w-full rounded-[10px] px-5 py-3 text-base font-semibold text-white"
+                style={{ background: 'var(--l-accent)' }}
+              >
+                Try the editor
+              </button>
+            </li>
+          </ul>
+        </nav>
+      )}
+    </header>
+  )
+}

--- a/src/landing/OriginStory.tsx
+++ b/src/landing/OriginStory.tsx
@@ -1,0 +1,121 @@
+import { navigate } from '@/lib/router.ts'
+import { REPO_URL } from '@/lib/constants.ts'
+
+// Phase 4 SA-8: replaces the spec's fake testimonials with a
+// truthful origin story and three real team cards. Dark section
+// for visual contrast against the light surrounding sections.
+
+const PRD_URL = `${REPO_URL}/blob/main/docs/PRD.md`
+
+interface TeamMember {
+  initials: string
+  name: string
+  role: string
+  body: string
+}
+
+const TEAM: ReadonlyArray<TeamMember> = [
+  {
+    initials: 'BD',
+    name: 'Bryan Djenabia',
+    role: 'UI, integration, deployment',
+    body:
+      'Owned the editor shell, the integration seam between the simulator and the UI, the design system, and the production deployment. Built the 5-band IDE layout, the file I/O system, and the command palette. Wrote the project plan.',
+  },
+  {
+    initials: 'LC',
+    name: 'Landon Clay',
+    role: 'Assembler and parser',
+    body:
+      'Designed the lexer and the two-pass assembler. Made label resolution work, encoded ~50 instructions across R/I/J types, and handled directives, pseudo-instructions, and the data segment layout.',
+  },
+  {
+    initials: 'ZG',
+    name: 'Zachary Gass',
+    role: 'Simulator and execution',
+    body:
+      'Built the simulator engine: 32 GPRs plus FPU registers, memory model with .text/.data/stack segments, the step/run loop, syscalls, and the test suite. Wrote 125+ tests verifying correctness against real MARS.',
+  },
+]
+
+export function OriginStory() {
+  return (
+    <section
+      id="team"
+      aria-labelledby="team-heading"
+      className="py-24 md:py-32"
+      style={{ background: 'var(--l-bg-dark)' }}
+    >
+      <div className="mx-auto max-w-7xl px-6">
+        {/* Header */}
+        <div className="mx-auto max-w-3xl text-center">
+          <span className="mono text-[13px] font-medium uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.1em' }}>
+            The team
+          </span>
+          <h2
+            id="team-heading"
+            className="mt-4 text-4xl font-bold leading-tight md:text-5xl"
+            style={{ color: 'white' }}
+          >
+            Three engineers. Six days. One simulator.
+          </h2>
+          <p className="mt-4 text-lg leading-[1.6]" style={{ color: '#A8B0C0' }}>
+            WebMARS is a senior software engineering capstone project. We set out to build a modern, browser-based replacement for MARS — the venerable MIPS simulator from Missouri State — in a single six-day sprint. We shipped on time. Then we kept going.
+          </p>
+        </div>
+
+        {/* Team cards */}
+        <div className="mt-16 grid gap-6 md:grid-cols-3">
+          {TEAM.map((m) => (
+            <article
+              key={m.name}
+              className="flex flex-col rounded-2xl p-8"
+              style={{
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.08)',
+                minHeight: 320,
+              }}
+            >
+              <div
+                className="flex size-16 items-center justify-center rounded-full text-2xl font-bold"
+                style={{ background: 'rgba(34,211,238,0.12)', color: 'var(--l-accent)' }}
+                aria-hidden="true"
+              >
+                {m.initials}
+              </div>
+              <h3 className="mt-4 text-lg font-bold" style={{ color: 'white' }}>{m.name}</h3>
+              <p className="mt-1 text-[13px] font-medium" style={{ color: 'var(--l-accent)' }}>{m.role}</p>
+              <p className="mt-4 text-[14px] leading-[1.6]" style={{ color: '#A8B0C0' }}>{m.body}</p>
+            </article>
+          ))}
+        </div>
+
+        {/* Closing */}
+        <div className="mx-auto mt-16 max-w-3xl text-center">
+          <p className="text-lg leading-[1.6]" style={{ color: '#A8B0C0' }}>
+            We built WebMARS because the canonical MARS simulator hadn&rsquo;t meaningfully changed since 2014, and a generation of students shouldn&rsquo;t have to fight Java Swing to learn computer architecture. Everything is open source. The code, the planning docs, the design tokens. Fork it. Improve it. Send a PR.
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <button
+              type="button"
+              onClick={() => navigate('/app')}
+              className="rounded-[10px] px-8 py-3 text-base font-semibold text-white transition-transform hover:-translate-y-0.5"
+              style={{ background: 'var(--l-accent)' }}
+            >
+              Try the editor →
+            </button>
+            <a
+              href={PRD_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-[10px] border-2 px-8 py-3 text-base font-semibold transition-colors"
+              style={{ borderColor: 'rgba(255,255,255,0.16)', color: 'white' }}
+            >
+              Read the PRD →
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/landing/OriginStory.tsx
+++ b/src/landing/OriginStory.tsx
@@ -43,7 +43,7 @@ export function OriginStory() {
     <section
       id="team"
       aria-labelledby="team-heading"
-      className="py-24 md:py-32"
+      className="landing-reveal py-24 md:py-32"
       style={{ background: 'var(--l-bg-dark)' }}
     >
       <div className="mx-auto max-w-7xl px-6">

--- a/src/landing/Personas.tsx
+++ b/src/landing/Personas.tsx
@@ -1,0 +1,125 @@
+import { navigate } from '@/lib/router.ts'
+import { REPO_URL } from '@/lib/constants.ts'
+
+// Phase 4 SA-7: who WebMARS is for. Three honest personas with
+// real bullets and CTAs that go to real destinations.
+
+const PRD_URL = `${REPO_URL}/blob/main/docs/PRD.md`
+
+interface Persona {
+  title: string
+  body: string
+  bullets: ReadonlyArray<string>
+  cta: { label: string; onClick: () => void }
+  icon: React.ReactNode
+}
+
+const PERSONAS: ReadonlyArray<Persona> = [
+  {
+    title: 'Students',
+    body:
+      'Learn MIPS without fighting Java installs or Swing UIs. Open the URL on your laptop in class, on your phone on the bus, on a friend’s machine in the lab. Your code runs the same everywhere.',
+    bullets: [
+      'Pre-loaded examples to get unstuck',
+      'Hover any instruction for the docs',
+      'Breakpoints when you can’t find your bug',
+    ],
+    cta: { label: 'Open the editor →', onClick: () => navigate('/app') },
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z" />
+        <path d="M22 10v6" />
+        <path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Educators',
+    body:
+      'Send a link instead of an installer. WebMARS works on any browser, any OS, any device — no IT tickets, no Java versions, no JAR downloads. Same simulator behavior as the canonical MARS.',
+    bullets: [
+      'One URL works for the whole class',
+      '8 example programs out of the box',
+      'Open source (MIT) — fork it, customize it',
+    ],
+    cta: { label: 'View on GitHub →', onClick: () => window.open(REPO_URL, '_blank', 'noopener,noreferrer') },
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+        <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Tinkerers',
+    body:
+      'Built in TypeScript on top of Monaco and Zustand. Documented, tested, and architected for extension. Add a new instruction, write a new tool, fork the whole thing. The codebase is small enough to read in a weekend.',
+    bullets: [
+      'Fully typed TypeScript codebase',
+      '125+ tests as documentation',
+      'Designed for extension',
+    ],
+    cta: { label: 'Read the architecture →', onClick: () => window.open(PRD_URL, '_blank', 'noopener,noreferrer') },
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+      </svg>
+    ),
+  },
+]
+
+export function Personas() {
+  return (
+    <section id="personas" aria-labelledby="personas-heading" className="py-24 md:py-32">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="max-w-3xl">
+          <span className="mono text-[13px] font-medium uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.1em' }}>
+            Who uses WebMARS
+          </span>
+          <h2 id="personas-heading" className="mt-4 text-4xl font-bold md:text-5xl" style={{ color: 'var(--l-ink-1)' }}>
+            Whoever&rsquo;s learning MIPS, this is built for you.
+          </h2>
+        </div>
+
+        <div className="mt-16 grid gap-8 md:grid-cols-3">
+          {PERSONAS.map((p) => (
+            <article
+              key={p.title}
+              className="flex flex-col rounded-2xl border bg-white p-10 transition-all hover:-translate-y-1"
+              style={{ borderColor: 'var(--l-border)', minHeight: 420 }}
+            >
+              <div
+                className="flex size-12 items-center justify-center rounded-xl"
+                style={{ background: 'var(--l-accent-soft)', color: 'var(--l-accent)' }}
+              >
+                <span className="size-6 block">{p.icon}</span>
+              </div>
+              <h3 className="mt-6 text-2xl font-bold" style={{ color: 'var(--l-ink-1)' }}>
+                {p.title}
+              </h3>
+              <p className="mt-3 text-[15px] leading-[1.6]" style={{ color: 'var(--l-ink-2)' }}>
+                {p.body}
+              </p>
+              <ul className="mt-5 flex flex-col gap-2">
+                {p.bullets.map((b) => (
+                  <li key={b} className="flex items-start gap-2 text-[14px]" style={{ color: 'var(--l-ink-1)' }}>
+                    <span aria-hidden="true" style={{ color: 'var(--l-success)' }}>✓</span>
+                    <span>{b}</span>
+                  </li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                onClick={p.cta.onClick}
+                className="mt-auto pt-6 text-left text-[15px] font-semibold transition-opacity hover:opacity-80"
+                style={{ color: 'var(--l-accent)' }}
+              >
+                {p.cta.label}
+              </button>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/landing/Personas.tsx
+++ b/src/landing/Personas.tsx
@@ -70,7 +70,7 @@ const PERSONAS: ReadonlyArray<Persona> = [
 
 export function Personas() {
   return (
-    <section id="personas" aria-labelledby="personas-heading" className="py-24 md:py-32">
+    <section id="personas" aria-labelledby="personas-heading" className="landing-reveal py-24 md:py-32">
       <div className="mx-auto max-w-7xl px-6">
         <div className="max-w-3xl">
           <span className="mono text-[13px] font-medium uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.1em' }}>

--- a/src/landing/ProofBar.tsx
+++ b/src/landing/ProofBar.tsx
@@ -1,0 +1,36 @@
+// Phase 4 SA-4: honest proof bar. The original spec called for
+// university adoption logos; we don't have any, so the section is
+// instead three real numbers from the project itself.
+
+const STATS = [
+  { value: '125+', label: 'Tests passing' },
+  { value: '50+',  label: 'MIPS instructions' },
+  { value: '6',    label: 'Tools built-in' },
+] as const
+
+export function ProofBar() {
+  return (
+    <section
+      aria-label="Project stats"
+      className="py-12"
+      style={{ background: 'var(--l-bg-alt)' }}
+    >
+      <div className="mx-auto flex max-w-7xl flex-col items-stretch gap-8 px-6 sm:flex-row sm:items-center sm:justify-around sm:divide-x" style={{ borderColor: 'var(--l-border)' }}>
+        {STATS.map((stat, i) => (
+          <div
+            key={stat.label}
+            className="flex flex-col items-center text-center"
+            style={i > 0 ? { borderColor: 'var(--l-border)' } : undefined}
+          >
+            <span className="text-4xl font-bold md:text-[36px]" style={{ color: 'var(--l-accent)' }}>
+              {stat.value}
+            </span>
+            <span className="mt-2 text-sm font-medium" style={{ color: 'var(--l-ink-2)' }}>
+              {stat.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/landing/ProofBar.tsx
+++ b/src/landing/ProofBar.tsx
@@ -12,7 +12,7 @@ export function ProofBar() {
   return (
     <section
       aria-label="Project stats"
-      className="py-12"
+      className="landing-reveal py-12"
       style={{ background: 'var(--l-bg-alt)' }}
     >
       <div className="mx-auto flex max-w-7xl flex-col items-stretch gap-8 px-6 sm:flex-row sm:items-center sm:justify-around sm:divide-x" style={{ borderColor: 'var(--l-border)' }}>

--- a/src/landing/Showcase.tsx
+++ b/src/landing/Showcase.tsx
@@ -1,0 +1,170 @@
+// Phase 4 SA-6: 4 alternating rows that go deep on what WebMARS
+// actually does. Screenshots are placeholder mocks until SA-11
+// captures real ones from the live deploy. Each row alternates
+// image/text orientation: left/right/left/right.
+
+interface Row {
+  eyebrow: string
+  title: string
+  body: string
+  imageSide: 'left' | 'right'
+  bullets?: ReadonlyArray<string>
+  thumbnails?: ReadonlyArray<string>
+  cta?: { label: string; onClick: () => void }
+  imagePlaceholder: React.ReactNode
+}
+
+function MockScreenshot({ label, accent }: { label: string; accent?: boolean }) {
+  return (
+    <div
+      className="flex aspect-[4/3] items-center justify-center overflow-hidden rounded-2xl mono text-sm"
+      style={{
+        background: accent ? 'var(--l-bg-dark)' : 'var(--l-bg-alt)',
+        color: accent ? 'var(--l-accent)' : 'var(--l-ink-3)',
+        boxShadow: 'var(--l-shadow-lg)',
+        border: '1px solid var(--l-border)',
+      }}
+    >
+      {label}
+    </div>
+  )
+}
+
+const ROWS: ReadonlyArray<Row> = [
+  {
+    eyebrow: 'Debugging',
+    title: 'Time-travel through your code.',
+    body:
+      'Set breakpoints with a single click in the gutter. Step forward through your program one instruction at a time, or use Backstep to undo. Watch registers highlight as they change and the console fill in real time.',
+    imageSide: 'left',
+    bullets: [
+      'Click-to-toggle gutter breakpoints',
+      'Forward and backward stepping',
+      'Live register-change highlighting',
+      'Adjustable execution speed (1 to 500 instr/s)',
+      'Run-to-cursor',
+    ],
+    imagePlaceholder: <MockScreenshot label="[ debugger screenshot — SA-11 ]" accent />,
+  },
+  {
+    eyebrow: 'Visual tools',
+    title: 'See inside the processor.',
+    body:
+      'WebMARS includes a Tools menu with the same kind of visual aids that make MARS so effective for teaching. Bitmap displays, MMIO simulators, IEEE 754 editors — all wired directly into the simulator state.',
+    imageSide: 'right',
+    thumbnails: [
+      'Bitmap Display',
+      'Keyboard MMIO',
+      'FP Representation',
+      'Instruction Counter',
+      'Memory Ref Viz',
+      'Screen Magnifier',
+    ],
+    imagePlaceholder: <MockScreenshot label="[ Bitmap Display — SA-11 ]" accent />,
+  },
+  {
+    eyebrow: 'Real files',
+    title: 'Save your work. Load other people’s.',
+    body:
+      'WebMARS uses the File System Access API to give you native open and save dialogs in supported browsers. Open .asm files from disk, edit them, save back. Open multiple files as tabs. No cloud, no account, no sync — your files stay on your machine.',
+    imageSide: 'left',
+    imagePlaceholder: <MockScreenshot label="[ multi-file tabs — SA-11 ]" />,
+  },
+  {
+    eyebrow: 'Built by students',
+    title: 'A class project that became a real tool.',
+    body:
+      'Three software engineering students set out to build a modern MIPS simulator in six days. The result was WebMARS: a full IDE with assembler, simulator, debugger, FPU, file I/O, and visual tools. Open source, MIT licensed, free to use forever.',
+    imageSide: 'right',
+    cta: {
+      label: 'Read the story →',
+      onClick: () => {
+        const target = document.getElementById('team')
+        if (target) target.scrollIntoView({ behavior: 'smooth' })
+      },
+    },
+    imagePlaceholder: <MockScreenshot label="[ team graphic — SA-11 ]" />,
+  },
+]
+
+export function Showcase() {
+  return (
+    <section id="showcase" aria-labelledby="showcase-heading" className="py-24 md:py-32" style={{ background: 'var(--l-bg-alt)' }}>
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="max-w-3xl">
+          <span className="mono text-[13px] font-medium uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.1em' }}>
+            See it in action
+          </span>
+          <h2 id="showcase-heading" className="mt-4 text-4xl font-bold md:text-5xl" style={{ color: 'var(--l-ink-1)' }}>
+            Built for how you actually learn assembly.
+          </h2>
+        </div>
+
+        <div className="mt-20 flex flex-col gap-24 md:gap-32">
+          {ROWS.map((row, i) => {
+            const imageFirst = row.imageSide === 'left'
+            return (
+              <article
+                key={i}
+                className="grid items-center gap-10 md:grid-cols-2 md:gap-16"
+              >
+                <div className={imageFirst ? 'md:order-1' : 'md:order-2'}>
+                  {row.imagePlaceholder}
+                </div>
+
+                <div className={imageFirst ? 'md:order-2' : 'md:order-1'}>
+                  <span className="mono text-[12px] font-medium uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.1em' }}>
+                    {row.eyebrow}
+                  </span>
+                  <h3 className="mt-3 text-3xl font-bold md:text-4xl" style={{ color: 'var(--l-ink-1)' }}>
+                    {row.title}
+                  </h3>
+                  <p className="mt-4 text-lg leading-[1.6]" style={{ color: 'var(--l-ink-2)' }}>
+                    {row.body}
+                  </p>
+
+                  {row.bullets && (
+                    <ul className="mt-6 flex flex-col gap-3">
+                      {row.bullets.map((b) => (
+                        <li key={b} className="flex items-center gap-3 text-[15px]" style={{ color: 'var(--l-ink-1)' }}>
+                          <span aria-hidden="true" style={{ color: 'var(--l-success)' }}>✓</span>
+                          {b}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+
+                  {row.thumbnails && (
+                    <div className="mt-6 flex gap-3 overflow-x-auto pb-2">
+                      {row.thumbnails.map((t) => (
+                        <div
+                          key={t}
+                          className="flex size-[120px] flex-none flex-col items-center justify-center rounded-lg border bg-white p-2 text-center text-[11px] font-medium"
+                          style={{ borderColor: 'var(--l-border)', color: 'var(--l-ink-2)' }}
+                        >
+                          {t}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {row.cta && (
+                    <button
+                      type="button"
+                      onClick={row.cta.onClick}
+                      className="mt-6 text-base font-semibold transition-opacity hover:opacity-80"
+                      style={{ color: 'var(--l-accent)' }}
+                    >
+                      {row.cta.label}
+                    </button>
+                  )}
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}
+

--- a/src/landing/Showcase.tsx
+++ b/src/landing/Showcase.tsx
@@ -1,7 +1,9 @@
 // Phase 4 SA-6: 4 alternating rows that go deep on what WebMARS
-// actually does. Screenshots are placeholder mocks until SA-11
-// captures real ones from the live deploy. Each row alternates
-// image/text orientation: left/right/left/right.
+// actually does. Each row's visual is a styled inline illustration
+// (no real screenshots) — mock IDE chrome with real code, a
+// CSS-rendered bitmap grid, multi-file tabs, and team avatars.
+// The illustrations match the eventual screenshot dimensions so
+// future captures slot in cleanly.
 
 interface Row {
   eyebrow: string
@@ -11,22 +13,186 @@ interface Row {
   bullets?: ReadonlyArray<string>
   thumbnails?: ReadonlyArray<string>
   cta?: { label: string; onClick: () => void }
-  imagePlaceholder: React.ReactNode
+  visual: React.ReactNode
 }
 
-function MockScreenshot({ label, accent }: { label: string; accent?: boolean }) {
+// Reusable card chrome for the row visuals.
+function VisualCard({ children, dark = true }: { children: React.ReactNode; dark?: boolean }) {
   return (
     <div
-      className="flex aspect-[4/3] items-center justify-center overflow-hidden rounded-2xl mono text-sm"
+      className="overflow-hidden rounded-2xl"
       style={{
-        background: accent ? 'var(--l-bg-dark)' : 'var(--l-bg-alt)',
-        color: accent ? 'var(--l-accent)' : 'var(--l-ink-3)',
+        background: dark ? 'var(--l-bg-dark)' : 'white',
         boxShadow: 'var(--l-shadow-lg)',
         border: '1px solid var(--l-border)',
+        aspectRatio: '4 / 3',
       }}
     >
-      {label}
+      {children}
     </div>
+  )
+}
+
+function DebuggerVisual() {
+  // Mock editor with a breakpoint dot, a flashing register, and a
+  // step indicator — communicates the debug story without a real
+  // capture.
+  return (
+    <VisualCard>
+      <div className="flex items-center gap-2 px-4 py-3" style={{ background: '#1a1d24' }}>
+        <span className="size-3 rounded-full" style={{ background: '#FF5F57' }} />
+        <span className="size-3 rounded-full" style={{ background: '#FEBC2E' }} />
+        <span className="size-3 rounded-full" style={{ background: '#28C840' }} />
+        <span className="ml-3 mono text-[12px]" style={{ color: '#A8B0C0' }}>syscallIO.asm</span>
+        <span className="ml-auto rounded px-2 py-0.5 mono text-[10px]" style={{ background: 'rgba(34,211,238,0.15)', color: 'var(--l-accent)' }}>
+          PAUSED · step 7
+        </span>
+      </div>
+      <div className="grid h-full grid-cols-[24px_1fr_200px]" style={{ background: 'var(--l-bg-dark)' }}>
+        {/* Gutter with breakpoint */}
+        <div className="flex flex-col items-center gap-3 border-r py-4 mono text-[10px]" style={{ borderColor: '#2A2F3A', color: '#5A6378' }}>
+          {[1,2,3,4,5,6,7].map((n) => (
+            <div key={n} className="relative">
+              {n === 4 && <span aria-hidden="true" className="absolute -left-2 top-0 size-2 rounded-full" style={{ background: '#EF4444' }} />}
+              {n}
+            </div>
+          ))}
+        </div>
+        {/* Source */}
+        <div className="px-4 py-4 mono text-[12px] leading-6" style={{ color: '#E2E5EC' }}>
+          <div><span style={{ color: '#7DD3FC' }}>main:</span></div>
+          <div>{'  '}<span style={{ color: '#22D3EE' }}>li</span> $v0, <span style={{ color: '#FFB020' }}>5</span></div>
+          <div>{'  '}<span style={{ color: '#22D3EE' }}>syscall</span></div>
+          <div className="rounded" style={{ background: 'rgba(34,211,238,0.10)' }}>{'  '}<span style={{ color: '#22D3EE' }}>move</span> $t0, $v0</div>
+          <div>{'  '}<span style={{ color: '#22D3EE' }}>li</span> $v0, <span style={{ color: '#FFB020' }}>1</span></div>
+          <div>{'  '}<span style={{ color: '#22D3EE' }}>move</span> $a0, $t0</div>
+          <div>{'  '}<span style={{ color: '#22D3EE' }}>syscall</span></div>
+        </div>
+        {/* Register sidebar with one flashing */}
+        <div className="border-l p-3 mono text-[11px]" style={{ borderColor: '#2A2F3A', color: '#A8B0C0' }}>
+          <div className="mb-2 uppercase text-[10px]" style={{ color: '#5A6378', letterSpacing: '0.1em' }}>Registers</div>
+          <div className="flex justify-between"><span>$v0</span><span style={{ color: '#22D3EE' }}>0x00000005</span></div>
+          <div className="-mx-2 flex justify-between rounded px-2 py-0.5" style={{ background: 'rgba(34,211,238,0.20)' }}><span>$t0</span><span style={{ color: '#22D3EE' }}>0x00000005</span></div>
+          <div className="flex justify-between"><span>$a0</span><span>0x00000000</span></div>
+          <div className="flex justify-between"><span>PC</span><span>0x0040000C</span></div>
+        </div>
+      </div>
+    </VisualCard>
+  )
+}
+
+function BitmapVisual() {
+  // 8x8 grid rendering the smile from bitmapSmile.asm — same
+  // pattern, rendered in CSS.
+  const Y = '#FFFF00'
+  const K = '#000000'
+  const grid = [
+    [K,K,K,K,K,K,K,K],
+    [K,Y,K,K,K,K,Y,K],
+    [K,Y,K,K,K,K,Y,K],
+    [K,K,K,K,K,K,K,K],
+    [K,K,K,K,K,K,K,K],
+    [Y,K,K,K,K,K,K,Y],
+    [K,Y,Y,Y,Y,Y,Y,K],
+    [K,K,K,K,K,K,K,K],
+  ]
+  return (
+    <VisualCard>
+      <div className="flex items-center gap-2 px-4 py-3" style={{ background: '#1a1d24' }}>
+        <span aria-hidden="true">▦</span>
+        <span className="mono text-[12px]" style={{ color: '#A8B0C0' }}>Bitmap Display · 8 × 8 · base 0x10010000</span>
+      </div>
+      <div className="flex h-full items-center justify-center p-6" style={{ background: '#0a0d12' }}>
+        <div
+          className="grid gap-0"
+          style={{ gridTemplateColumns: 'repeat(8, 28px)', gridTemplateRows: 'repeat(8, 28px)', boxShadow: '0 0 60px rgba(34,211,238,0.15)' }}
+          role="img"
+          aria-label="A yellow smile face on a black background, drawn into memory by bitmapSmile.asm"
+        >
+          {grid.flat().map((c, i) => (
+            <div key={i} style={{ background: c }} />
+          ))}
+        </div>
+      </div>
+    </VisualCard>
+  )
+}
+
+function MultiFileVisual() {
+  const tabs = [
+    { name: 'arraySum.asm',   active: false, modified: false },
+    { name: 'factorial.asm',  active: true,  modified: true  },
+    { name: 'sumToN.asm',     active: false, modified: false },
+  ]
+  return (
+    <VisualCard>
+      <div className="flex items-center gap-2 px-4 py-3" style={{ background: '#1a1d24' }}>
+        <span className="size-3 rounded-full" style={{ background: '#FF5F57' }} />
+        <span className="size-3 rounded-full" style={{ background: '#FEBC2E' }} />
+        <span className="size-3 rounded-full" style={{ background: '#28C840' }} />
+      </div>
+      <div className="flex items-stretch border-b" style={{ background: '#11141a', borderColor: '#2A2F3A' }}>
+        {tabs.map((t) => (
+          <div
+            key={t.name}
+            className="flex items-center gap-2 border-r px-4 py-2 mono text-[12px]"
+            style={{
+              borderColor: '#2A2F3A',
+              background: t.active ? 'var(--l-bg-dark)' : 'transparent',
+              color: t.active ? 'white' : '#A8B0C0',
+            }}
+          >
+            {t.modified && <span aria-hidden="true" className="size-1.5 rounded-full" style={{ background: 'var(--l-warn)' }} />}
+            {t.name}
+          </div>
+        ))}
+        <div className="flex items-center px-3 mono text-base" style={{ color: '#5A6378' }}>+</div>
+      </div>
+      <div className="px-4 py-4 mono text-[12px] leading-6" style={{ background: 'var(--l-bg-dark)', color: '#E2E5EC' }}>
+        <div><span style={{ color: '#7DD3FC' }}>factorial:</span></div>
+        <div>{'  '}<span style={{ color: '#22D3EE' }}>addi</span> $sp, $sp, <span style={{ color: '#FFB020' }}>-8</span></div>
+        <div>{'  '}<span style={{ color: '#22D3EE' }}>sw</span> $ra, <span style={{ color: '#FFB020' }}>0</span>($sp)</div>
+        <div>{'  '}<span style={{ color: '#22D3EE' }}>sw</span> $a0, <span style={{ color: '#FFB020' }}>4</span>($sp)</div>
+        <div>{'  '}<span style={{ color: '#22D3EE' }}>blt</span> $a0, <span style={{ color: '#FFB020' }}>2</span>, base</div>
+      </div>
+    </VisualCard>
+  )
+}
+
+function TeamVisual() {
+  // Three avatar circles + name labels in a card. Uses the same
+  // initials and roles as the OriginStory section.
+  const members = [
+    { initials: 'BD', name: 'Bryan',  role: 'UI · Integration' },
+    { initials: 'LC', name: 'Landon', role: 'Assembler · Parser' },
+    { initials: 'ZG', name: 'Zach',   role: 'Simulator · Tests' },
+  ]
+  return (
+    <VisualCard>
+      <div className="flex h-full flex-col justify-center px-8 py-10" style={{ background: 'var(--l-bg-dark)' }}>
+        <div className="mono text-[11px] uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.1em' }}>
+          The team · 6-day sprint
+        </div>
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-6">
+          {members.map((m) => (
+            <div key={m.name} className="flex flex-col items-center gap-2">
+              <div
+                className="flex size-20 items-center justify-center rounded-full text-2xl font-bold"
+                style={{ background: 'rgba(34,211,238,0.15)', color: 'var(--l-accent)' }}
+                aria-hidden="true"
+              >
+                {m.initials}
+              </div>
+              <div className="text-base font-bold" style={{ color: 'white' }}>{m.name}</div>
+              <div className="mono text-[11px]" style={{ color: '#A8B0C0' }}>{m.role}</div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-6 text-center text-[13px]" style={{ color: '#A8B0C0' }}>
+          Modeled after MARS · Built in TypeScript · 125+ tests
+        </div>
+      </div>
+    </VisualCard>
   )
 }
 
@@ -44,7 +210,7 @@ const ROWS: ReadonlyArray<Row> = [
       'Adjustable execution speed (1 to 500 instr/s)',
       'Run-to-cursor',
     ],
-    imagePlaceholder: <MockScreenshot label="[ debugger screenshot — SA-11 ]" accent />,
+    visual: <DebuggerVisual />,
   },
   {
     eyebrow: 'Visual tools',
@@ -60,7 +226,7 @@ const ROWS: ReadonlyArray<Row> = [
       'Memory Ref Viz',
       'Screen Magnifier',
     ],
-    imagePlaceholder: <MockScreenshot label="[ Bitmap Display — SA-11 ]" accent />,
+    visual: <BitmapVisual />,
   },
   {
     eyebrow: 'Real files',
@@ -68,7 +234,7 @@ const ROWS: ReadonlyArray<Row> = [
     body:
       'WebMARS uses the File System Access API to give you native open and save dialogs in supported browsers. Open .asm files from disk, edit them, save back. Open multiple files as tabs. No cloud, no account, no sync — your files stay on your machine.',
     imageSide: 'left',
-    imagePlaceholder: <MockScreenshot label="[ multi-file tabs — SA-11 ]" />,
+    visual: <MultiFileVisual />,
   },
   {
     eyebrow: 'Built by students',
@@ -83,7 +249,7 @@ const ROWS: ReadonlyArray<Row> = [
         if (target) target.scrollIntoView({ behavior: 'smooth' })
       },
     },
-    imagePlaceholder: <MockScreenshot label="[ team graphic — SA-11 ]" />,
+    visual: <TeamVisual />,
   },
 ]
 
@@ -109,7 +275,7 @@ export function Showcase() {
                 className="grid items-center gap-10 md:grid-cols-2 md:gap-16"
               >
                 <div className={imageFirst ? 'md:order-1' : 'md:order-2'}>
-                  {row.imagePlaceholder}
+                  {row.visual}
                 </div>
 
                 <div className={imageFirst ? 'md:order-2' : 'md:order-1'}>

--- a/src/landing/Showcase.tsx
+++ b/src/landing/Showcase.tsx
@@ -89,7 +89,7 @@ const ROWS: ReadonlyArray<Row> = [
 
 export function Showcase() {
   return (
-    <section id="showcase" aria-labelledby="showcase-heading" className="py-24 md:py-32" style={{ background: 'var(--l-bg-alt)' }}>
+    <section id="showcase" aria-labelledby="showcase-heading" className="landing-reveal py-24 md:py-32" style={{ background: 'var(--l-bg-alt)' }}>
       <div className="mx-auto max-w-7xl px-6">
         <div className="max-w-3xl">
           <span className="mono text-[13px] font-medium uppercase" style={{ color: 'var(--l-accent)', letterSpacing: '0.1em' }}>

--- a/src/landing/tokens.css
+++ b/src/landing/tokens.css
@@ -1,0 +1,37 @@
+/* Phase 4 landing-page design tokens. Scoped to .landing so the
+   IDE's existing dark tokens (src/ui/tokens.css) are untouched. */
+
+.landing {
+  /* Light palette — different from the IDE's dark theme */
+  --l-bg:           #FFFFFF;
+  --l-bg-alt:       #F7F8FB;
+  --l-bg-dark:      #0F1419;
+  --l-border:       #E2E5EC;
+  --l-ink-1:        #1A1D24;
+  --l-ink-2:        #5A6378;
+  --l-ink-3:        #8B95A8;
+
+  /* Reuse the IDE's accent so the brand color matches both pages */
+  --l-accent:       #22D3EE;
+  --l-accent-dark:  #0E7490;
+  --l-accent-soft:  rgba(34, 211, 238, 0.10);
+
+  --l-success:      #00B86B;
+  --l-warn:         #FFB020;
+
+  --l-radius-card:  16px;
+  --l-radius-btn:   10px;
+
+  --l-shadow-sm:    0 1px 3px rgba(0,0,0,0.06);
+  --l-shadow-md:    0 4px 16px rgba(0,0,0,0.08);
+  --l-shadow-lg:    0 12px 40px rgba(0,0,0,0.12);
+  --l-shadow-xl:    0 24px 64px rgba(0,0,0,0.16);
+
+  font-family: 'Inter', system-ui, sans-serif;
+  color: var(--l-ink-1);
+  background: var(--l-bg);
+}
+
+.landing .mono {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}

--- a/src/landing/tokens.css
+++ b/src/landing/tokens.css
@@ -35,3 +35,70 @@
 .landing .mono {
   font-family: 'JetBrains Mono', ui-monospace, monospace;
 }
+
+/* Phase 4 SA-12: skip-to-content link. Visible only when focused
+   via keyboard so screen-reader and keyboard users can bypass the
+   nav. */
+.landing .skip-link {
+  position: absolute;
+  top: -40px;
+  left: 12px;
+  z-index: 100;
+  background: var(--l-ink-1);
+  color: white;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: top 200ms ease-out;
+}
+.landing .skip-link:focus,
+.landing .skip-link:focus-visible {
+  top: 12px;
+  outline: 2px solid var(--l-accent);
+  outline-offset: 2px;
+}
+
+/* Scroll-triggered entrance animations. Sections fade + slide up
+   24px as they enter the viewport. The .landing-reveal class is
+   applied immediately; .landing-revealed is added by the
+   IntersectionObserver in LandingPage when the element crosses
+   the threshold. Triggered exactly once per section. */
+.landing .landing-reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 600ms ease-out, transform 600ms ease-out;
+  will-change: opacity, transform;
+}
+.landing .landing-reveal.landing-revealed {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Hero floating animation (subtle 4s lift loop). Disabled by
+   reduced-motion. */
+@keyframes landing-float {
+  0%, 100% { transform: perspective(1200px) rotateY(-5deg) rotateX(2deg) translateY(0); }
+  50%      { transform: perspective(1200px) rotateY(-5deg) rotateX(2deg) translateY(-4px); }
+}
+.landing .hero-visual-float {
+  animation: landing-float 4s ease-in-out infinite;
+}
+
+/* prefers-reduced-motion: kill all entrance animations and the
+   hero float. Keep instant state changes. */
+@media (prefers-reduced-motion: reduce) {
+  .landing .landing-reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+  .landing .hero-visual-float {
+    animation: none;
+  }
+  .landing * {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+// Phase 4 SA-1: minimal client-side router. The app has exactly two
+// routes (/ for the landing page, /app for the IDE) and adding
+// react-router-dom for that scope would be overkill. This 30-line
+// shim wraps window.history + popstate into a useRoute() hook.
+//
+// navigate('/app') pushes a new history entry and dispatches a
+// synthetic popstate so any subscribed useRoute() instances rerender.
+// The browser's back/forward buttons fire popstate natively.
+
+export type Route = 'landing' | 'app'
+
+export function getCurrentRoute(): Route {
+  if (typeof window === 'undefined') return 'landing'
+  return window.location.pathname.startsWith('/app') ? 'app' : 'landing'
+}
+
+export function navigate(to: '/' | '/app'): void {
+  if (typeof window === 'undefined') return
+  if (window.location.pathname === to) return
+  window.history.pushState({}, '', to)
+  window.dispatchEvent(new PopStateEvent('popstate'))
+}
+
+export function useRoute(): Route {
+  const [route, setRoute] = useState<Route>(getCurrentRoute())
+  useEffect(() => {
+    function onPop(): void { setRoute(getCurrentRoute()) }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [])
+  return route
+}

--- a/src/ui/MenuBar.tsx
+++ b/src/ui/MenuBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSimulator, type RecentFile, type ThemeName, type NumberBase } from '@/hooks/useSimulator.ts'
 import { runEditorAction } from '@/lib/editorActions.ts'
 import { REPO_URL, ISSUES_URL } from '@/lib/constants.ts'
+import { navigate } from '@/lib/router.ts'
 import { cn } from './cn.ts'
 
 // Each menu item is either a clickable action, a disabled placeholder
@@ -384,6 +385,20 @@ export function MenuBar() {
           </div>
         )
       })}
+
+      {/* Phase 4 SA-1: subtle "← Home" link back to the landing
+         page. Right-anchored so it doesn't crowd the menu items.
+         Users who deep-link to /app generally don't want to leave,
+         so this stays minimal. */}
+      <span className="flex-1" aria-hidden="true" />
+      <button
+        type="button"
+        onClick={() => navigate('/')}
+        title="Back to landing page"
+        className="rounded-sm px-2 py-1 text-[11px] text-ink-3 transition-colors hover:bg-surface-2 hover:text-ink-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+      >
+        ← Home
+      </button>
     </header>
   )
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/((?!assets/).*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Phase 4 builds a real marketing landing page at `/` and moves the existing IDE to `/app`. The IDE component tree is **not** modified — only the routing shim is new.

## SA-1 (this commit batch)

- src/lib/router.ts — 30-line history-API router (no react-router-dom dep)
- src/App.tsx — lazy-loads the landing page, mounts Shell at /app
- vercel.json — SPA rewrite so direct deep-links to /app refresh correctly
- src/ui/MenuBar.tsx — subtle '← Home' link in the right side of the menubar
- src/landing/LandingPage.tsx — placeholder, expanded by SA-2..SA-10
- src/landing/tokens.css — landing-only design tokens scoped to .landing

## Verification

- typecheck + lint + build green
- 125/125 tests still passing (IDE untouched)

## Remaining SAs

SA-2 shell + tokens, SA-3 nav + hero, SA-4 proof bar, SA-5 features, SA-6 showcase, SA-7 personas, SA-8 origin story (replaces fake testimonials), SA-9 final CTA, SA-10 footer, SA-11 real screenshots, SA-12 responsive + a11y + perf, SA-13 final polish + Vercel verify.