### PR TITLE
feat(routing): IDE at /, landing page at /about

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The project is built in TypeScript with React, Vite, and Tailwind CSS, and runs 
 
 ## Live demo
 
-Visit **[webmarsimulator.com](https://www.webmarsimulator.com/)** for the project landing page, or jump straight to the IDE at **[webmarsimulator.com/app](https://www.webmarsimulator.com/app)**.
+The IDE is at **[webmarsimulator.com](https://www.webmarsimulator.com/)**. The about page (project background, team, features) is at **[webmarsimulator.com/about](https://www.webmarsimulator.com/about)**.
 
 ## Status
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <!-- Open Graph (image deferred — no captured screenshot yet) -->
     <meta property="og:title" content="WebMARS — MIPS in your browser" />
     <meta property="og:description" content="A modern, browser-based MIPS simulator with full IDE, debugger, and visual tools." />
-    <meta property="og:url" content="https://www.webmarsimulator.com/" />
+    <meta property="og:url" content="https://www.webmarsimulator.com/about" />
     <meta property="og:type" content="website" />
 
     <!-- Twitter -->

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://www.webmarsimulator.com/</loc><changefreq>monthly</changefreq><priority>1.0</priority></url>
-  <url><loc>https://www.webmarsimulator.com/app</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://www.webmarsimulator.com/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://www.webmarsimulator.com/about</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/landing/FinalCTA.tsx
+++ b/src/landing/FinalCTA.tsx
@@ -7,7 +7,7 @@ import { REPO_URL, ISSUES_URL } from '@/lib/constants.ts'
 // real secondary links underneath.
 
 const PRD_URL = `${REPO_URL}/blob/main/docs/PRD.md`
-const APP_URL = 'https://www.webmarsimulator.com/app'
+const APP_URL = 'https://www.webmarsimulator.com/'
 
 export function FinalCTA() {
   const [copied, setCopied] = useState(false)
@@ -60,7 +60,7 @@ export function FinalCTA() {
 
           <button
             type="button"
-            onClick={() => navigate('/app')}
+            onClick={() => navigate('/')}
             className="mt-2 w-full rounded-[10px] px-8 text-base font-semibold text-white transition-transform hover:-translate-y-0.5"
             style={{ background: 'var(--l-accent)', height: 56 }}
           >

--- a/src/landing/Footer.tsx
+++ b/src/landing/Footer.tsx
@@ -50,7 +50,7 @@ export function Footer() {
             <li>
               <button
                 type="button"
-                onClick={() => navigate('/app')}
+                onClick={() => navigate('/')}
                 className="transition-colors hover:[color:white]"
                 style={{ color: '#A8B0C0' }}
               >

--- a/src/landing/Hero.tsx
+++ b/src/landing/Hero.tsx
@@ -49,7 +49,7 @@ export function Hero() {
             <div className="flex flex-col">
               <button
                 type="button"
-                onClick={() => navigate('/app')}
+                onClick={() => navigate('/')}
                 className="group flex items-center justify-center gap-2 rounded-[10px] px-8 text-base font-semibold text-white transition-all hover:-translate-y-0.5"
                 style={{
                   background: 'var(--l-accent)',

--- a/src/landing/Nav.tsx
+++ b/src/landing/Nav.tsx
@@ -77,7 +77,7 @@ export function Nav() {
           </a>
           <button
             type="button"
-            onClick={() => navigate('/app')}
+            onClick={() => navigate('/')}
             className="rounded-[10px] px-5 text-[15px] font-semibold text-white transition-transform hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--l-accent)]"
             style={{ background: 'var(--l-accent)', height: 40 }}
           >
@@ -132,7 +132,7 @@ export function Nav() {
             <li className="pt-2">
               <button
                 type="button"
-                onClick={() => { setMobileOpen(false); navigate('/app') }}
+                onClick={() => { setMobileOpen(false); navigate('/') }}
                 className="w-full rounded-[10px] px-5 py-3 text-base font-semibold text-white"
                 style={{ background: 'var(--l-accent)' }}
               >

--- a/src/landing/OriginStory.tsx
+++ b/src/landing/OriginStory.tsx
@@ -98,7 +98,7 @@ export function OriginStory() {
           <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <button
               type="button"
-              onClick={() => navigate('/app')}
+              onClick={() => navigate('/')}
               className="rounded-[10px] px-8 py-3 text-base font-semibold text-white transition-transform hover:-translate-y-0.5"
               style={{ background: 'var(--l-accent)' }}
             >

--- a/src/landing/Personas.tsx
+++ b/src/landing/Personas.tsx
@@ -24,7 +24,7 @@ const PERSONAS: ReadonlyArray<Persona> = [
       'Hover any instruction for the docs',
       'Breakpoints when you can’t find your bug',
     ],
-    cta: { label: 'Open the editor →', onClick: () => navigate('/app') },
+    cta: { label: 'Open the editor →', onClick: () => navigate('/') },
     icon: (
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z" />

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,22 +1,22 @@
 import { useEffect, useState } from 'react'
 
-// Phase 4 SA-1: minimal client-side router. The app has exactly two
-// routes (/ for the landing page, /app for the IDE) and adding
-// react-router-dom for that scope would be overkill. This 30-line
-// shim wraps window.history + popstate into a useRoute() hook.
+// Phase 4 routing. The IDE is the default route (/) so existing
+// users and direct deep-links land on the editor without an extra
+// hop. The marketing landing page lives at /about.
 //
-// navigate('/app') pushes a new history entry and dispatches a
-// synthetic popstate so any subscribed useRoute() instances rerender.
-// The browser's back/forward buttons fire popstate natively.
+// navigate('/about') pushes a new history entry and dispatches a
+// synthetic popstate so any subscribed useRoute() instances
+// rerender. The browser's back/forward buttons fire popstate
+// natively.
 
-export type Route = 'landing' | 'app'
+export type Route = 'app' | 'landing'
 
 export function getCurrentRoute(): Route {
-  if (typeof window === 'undefined') return 'landing'
-  return window.location.pathname.startsWith('/app') ? 'app' : 'landing'
+  if (typeof window === 'undefined') return 'app'
+  return window.location.pathname.startsWith('/about') ? 'landing' : 'app'
 }
 
-export function navigate(to: '/' | '/app'): void {
+export function navigate(to: '/' | '/about'): void {
   if (typeof window === 'undefined') return
   if (window.location.pathname === to) return
   window.history.pushState({}, '', to)

--- a/src/ui/MenuBar.tsx
+++ b/src/ui/MenuBar.tsx
@@ -386,18 +386,18 @@ export function MenuBar() {
         )
       })}
 
-      {/* Phase 4 SA-1: subtle "← Home" link back to the landing
-         page. Right-anchored so it doesn't crowd the menu items.
-         Users who deep-link to /app generally don't want to leave,
-         so this stays minimal. */}
+      {/* Phase 4: subtle 'About' link to the marketing page at
+         /about. Right-anchored so it doesn't crowd the menu
+         items; the IDE itself is the default route (/) so this
+         stays minimal. */}
       <span className="flex-1" aria-hidden="true" />
       <button
         type="button"
-        onClick={() => navigate('/')}
-        title="Back to landing page"
+        onClick={() => navigate('/about')}
+        title="About this project"
         className="rounded-sm px-2 py-1 text-[11px] text-ink-3 transition-colors hover:bg-surface-2 hover:text-ink-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
       >
-        ← Home
+        About
       </button>
     </header>
   )


### PR DESCRIPTION
Flips the URL structure so the IDE is the default route and the landing page sits behind /about. Most developer tools work this way — returning users shouldn't have to click through a marketing page to reach the editor.

## Changes

- src/lib/router.ts: default route is 'app'; /about routes to 'landing'.
- All landing CTAs (Nav, Hero, Personas, OriginStory, FinalCTA, Footer drawer) navigate to / instead of /app.
- IDE menubar's '← Home' becomes 'About' pointing at /about.
- FinalCTA URL display, sitemap.xml, README live-demo copy, index.html og:url all updated.

## Verification

- typecheck + lint + build + 125/125 tests green
- vercel.json SPA rewrite still handles /about deep-links
- No /app references left in src/