### PR TITLE
fix: phase 4.5 — wire landing page route + split README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,319 +1,192 @@
 # WebMARS
 
 A modern, browser-based MIPS Assembler and Runtime Simulator.
+**Live at [webmarsimulator.com](https://www.webmarsimulator.com/).**
 
-WebMARS is a functional re-implementation of the core features of the original [MARS](https://courses.missouristate.edu/KenVollmar/MARS/) simulator, rebuilt as a web application. It is designed for students learning MIPS assembly who want a clean, fast, installation-free alternative to the original Java Swing tool.
+## What it is
 
-The project is built in TypeScript with React, Vite, and Tailwind CSS, and runs entirely in the browser.
+WebMARS is a complete MIPS development environment — assembler, simulator,
+debugger, and visual tools — running entirely in the browser. It is a
+re-implementation of the curriculum-standard
+[MARS](https://courses.missouristate.edu/KenVollmar/MARS/) simulator,
+rebuilt as a web app so students don't have to fight Java installs.
+Built in TypeScript with React 19, Vite, Tailwind, Monaco, and Zustand.
 
-## Live demo
+## Quick links
 
-The IDE is at **[webmarsimulator.com](https://www.webmarsimulator.com/)**. The about page (project background, team, features) is at **[webmarsimulator.com/about](https://www.webmarsimulator.com/about)**.
+- Live editor — <https://www.webmarsimulator.com/>
+- About page — <https://www.webmarsimulator.com/about>
+- GitHub — <https://github.com/Webmarssimulator/WebMARS>
+- Report a bug — <https://github.com/Webmarssimulator/WebMARS/issues>
+- PRD — [`docs/PRD.md`](./docs/PRD.md)
+- Final report — [`docs/FINAL_REPORT.md`](./docs/FINAL_REPORT.md)
 
-## Status
+---
 
-v1.1.0. Every PRD must-have and stretch goal shipped, plus the Phase 3 bug-fix sweep: missing pseudo-instructions, console first-byte fix, resizable panels, in-app help dialog, breakpoint hover preview, full Tools menu (Bitmap Display, MMIO simulator, IEEE 754 representation, memory reference visualization, screen magnifier), reworked mobile shell with tabbed layout. 119 tests passing.
+## Getting started (Usage)
 
-See [the PRD](./docs/PRD.md) for the full scope, timeline, and roadmap, [the final report](./docs/FINAL_REPORT.md) for the project writeup, or [the demo script](./docs/DEMO_SCRIPT.md) for a seven-minute walkthrough.
+*For students and educators who want to use WebMARS.*
 
-## Features
+Just visit <https://www.webmarsimulator.com/>. No install required.
 
-The v1.1.0 release covers every workflow the curriculum needs, plus a Tools menu that goes well beyond the original PRD.
+### Writing your first program
 
-### Editor and assembler
+1. Click **File → Examples → Hello, MIPS!** (or any other example).
+2. Click **Assemble** in the toolbar (or press `F3`).
+3. Click **Run** (or press `F5`).
+4. Output appears in the Console at the bottom.
 
-- Monaco editor with custom MIPS syntax highlighting and hover docs.
-- Inline assembler-error squiggles plus an error overview ruler in the margin.
-- Low-opacity breakpoint preview on gutter hover so users discover where to click.
-- Two-pass MIPS32 assembler covering ~60 instructions across arithmetic, logical, shift, branch, jump, load/store, FPU, and trap families.
-- Pseudo-instructions: `li`, `la`, `move`, `blt`, `ble`, `bgt`, `bge`, `abs`, `sge`, `sgt`, `neg`, `not`, `nop`.
-- `.globl` directive accepted as a no-op for single-file assembly.
+### Common workflows
 
-### Runtime and debugging
+- **Open a file from your computer** — File → Open. Chromium browsers
+  use the native picker; Firefox falls back to a download dialog on save.
+- **Save your work** — File → Save (or `Ctrl+S`). Files stay on your
+  machine; nothing is uploaded.
+- **Set a breakpoint** — click in the gutter to the left of any line.
+  Hover the gutter for a low-opacity preview before you click.
+- **Step through code** — `F7` advances one instruction. `Shift+F7`
+  rewinds (yes, you can step backward).
+- **Run to cursor** — place the cursor on a line, press `F8`.
+- **Inspect state** — the right inspector shows the register file
+  (with per-step change highlighting) and a memory view with `.text`
+  / `.data` / stack toggles. The FPU panel can be enabled in Settings.
+- **Open the Tools menu** — Bitmap Display, Keyboard/Display MMIO,
+  IEEE 754 Representation, Memory Reference Visualization, Screen
+  Magnifier, and Instruction Counter.
 
-- Run, Pause, Step, Backstep, Run-to-cursor, Reset controls plus a 1–500 instr/s speed slider.
-- Backstep rewinds register state AND memory writes via a 200-entry circular snapshot history.
-- Click-to-set breakpoints in the editor gutter, persisted per file.
-- Live register file with per-step change highlighting; toggleable hex / decimal / binary views.
-- Toggleable FPU panel showing $f0–$f31 in float and bits along with the FCSR cc[0] flag.
-- Memory inspector with segment toggle (`.text` / `.data` / stack), base-address jump, edit-in-place, and a flash on each write.
-- Console handles syscall I/O via an inline input field; Messages and Problems panels aggregate runtime + assembler errors with click-to-jump.
+### Keyboard shortcuts
 
-### File system and editor shell
+Press `F1` anywhere in the editor for the full reference. Highlights:
 
-- Multi-file tabs with drag-to-reorder, right-click context menu, and an Open Recent submenu.
-- File System Access API for native open/save in Chromium browsers; download fallback in Firefox.
-- Resizable panels — drag the strip between the source pane and the bottom panel, or between the center and the right inspector. Sizes persist across reloads. Keyboard accessible (arrow keys nudge, Home resets).
-- Bundled example programs: array sum, factorial, string print, sum 1..N, syscall I/O, FPU float math, MMIO keyboard echo.
-- Symbol table panel and searchable instruction reference panel in the left rail.
-- Settings cog at the bottom of the left rail opens the Settings dialog.
+| Action | Shortcut |
+|---|---|
+| Help dialog | `F1` |
+| Assemble | `F3` |
+| Run | `F5` |
+| Pause | `F6` |
+| Step | `F7` |
+| Backstep | `Shift+F7` |
+| Run to cursor | `F8` |
+| Toggle breakpoint | `F9` |
+| Save | `Ctrl+S` |
+| Open | `Ctrl+O` |
+| New | `Ctrl+N` |
+| Find / Replace | `Ctrl+F` / `Ctrl+H` |
+| Goto line | `Ctrl+G` |
+| Settings | `Ctrl+,` |
+| Command palette | `Ctrl+Shift+P` |
 
-### Settings, commands, keyboard
+### Browser support
 
-- Settings dialog with dark / light / high-contrast themes, editor font size, simulator toggles (FPU panel, delayed branching, self-modifying code).
-- Command palette (`Ctrl+Shift+P`) with fuzzy search across every action.
-- In-app help dialog (`F1` or the `?` button in the toolbar) with six tabs: Basic Instructions, Pseudo-Instructions, Directives, Syscalls, Exceptions, About.
-- Keyboard shortcuts: F1 help, F3 assemble, F5 run, F6 pause, F7 step, Shift+F7 backstep, F8 run to cursor, F9 toggle breakpoint, Ctrl+S save, Ctrl+O open, Ctrl+N new, Ctrl+G goto-line, Ctrl+F find, Ctrl+H replace, Ctrl+B/Ctrl+J/Ctrl+Alt+B layout, Ctrl+, settings.
+Modern Chrome, Edge, Firefox, and Safari. The File System Access API
+for direct file open/save is Chromium-only; Firefox and Safari fall
+back to download dialogs on save. All other features work everywhere.
 
-### Tools menu
+---
 
-- **Instruction Counter** — static mnemonic histogram + runtime step count.
-- **Bitmap Display** — treats a region of memory as a 2D pixel grid; configurable cell size, dimensions, base address.
-- **Keyboard / Display MMIO** — memory-mapped I/O at 0xffff0000–0xffff000c with engine-side support and an interactive UI.
-- **Floating-Point Representation** — bit-level IEEE 754 single-precision editor with sign / exponent / mantissa decode.
-- **Memory Reference Visualization** — top-50 horizontal bar chart of accessed addresses.
-- **Screen Magnifier** — floating loupe overlay for projector demos.
-- Placeholders for v2.0: Cache Simulator, MIPS X-Ray, BHT Simulator, Digital Lab Sim, Scavenger Hunt, Mars Bot.
+## Self-installation (Developers)
 
-### Mobile
-
-- Under 768px viewport, the shell switches to a tabbed mobile layout: hamburger drawer for menus, four tabs (Editor / Registers / Memory / Console), full-width control bar (Assemble / Run / Pause / Step / Reset).
-- The editor is read-only by default with an Edit toggle in the header. Word wrap is on; the minimap is hidden.
-
-## Getting Started
-
-WebMARS is published as a static web build and requires no installation to use. The live build is at **[webmarsimulator.com](https://www.webmarsimulator.com/)** — open it in a Chromium-based browser (Chrome, Edge, Brave, Arc) for the full feature set. See [`docs/VERCEL_DEPLOY.md`](./docs/VERCEL_DEPLOY.md) for the deploy walkthrough.
-
-To run the project locally for development, follow the instructions below.
+*For developers who want to fork, modify, or run the project locally.*
 
 ### Prerequisites
 
-- Node.js 20 or later.
-- npm 10 or later. Yarn and pnpm are also supported but not officially tested.
-- A Chromium-based browser (Chrome, Edge, Brave, Arc) for the full feature set. Firefox works but falls back to download-based saves because the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) is Chromium-only.
+- Node.js 20 or later
+- npm 10 or later (bundled with Node)
+- Git
 
-### Installation
+### Setup
 
-```powershell
-git clone https://github.com/BryanD17/WebMARS.git
+```bash
+git clone https://github.com/Webmarssimulator/WebMARS.git
 cd WebMARS
 npm install
-```
-
-### Verify the install
-
-```powershell
-npm test
-```
-
-You should see all tests passing (currently 103). If they don't, the local checkout is broken — fix that before continuing.
-
-### Running the development server
-
-```powershell
 npm run dev
 ```
 
-Vite prints the local URL it picked. By default that is `http://localhost:5173`, but Vite will fall through to `5174`, `5175`, … if 5173 is already in use (a previous dev server, another project), so always read the URL Vite prints rather than assuming the default.
+Vite prints the local URL. By default it's `http://localhost:5173`,
+but Vite falls through to `5174`, `5175`, … if 5173 is taken.
 
-Saving a source file in `src/` triggers an HMR reload in the open browser tab — most edits land in well under a second.
-
-### Building for production
-
-```powershell
-npm run build
-npm run preview
-```
-
-The build output is written to `dist/` and can be served by any static host. `npm run preview` serves that same output locally so you can spot-check the production bundle before deploying. Vercel deploys from the same `npm run build` step — see [`docs/VERCEL_DEPLOY.md`](./docs/VERCEL_DEPLOY.md).
-
-### Other useful scripts
-
-```powershell
-npm run typecheck     # strict TypeScript check, no emit
-npm run lint          # ESLint across src/ and tests/
-npm run test:watch    # vitest in watch mode
-```
-
-## Usage
-
-1. Open WebMARS in a modern browser.
-2. Paste or type MIPS assembly into the source editor on the left.
-3. Click **Assemble** in the top bar. Errors, if any, appear in the status bar with line numbers.
-4. Use **Run** to execute the program to completion, or **Step** to advance one instruction at a time.
-5. Watch the register file update live in the right panel. Switch tabs to inspect memory or read console output.
-6. Use **Reset** to return the simulator to its initial state without re-assembling.
-
-### Example program
-
-```mips
-        .data
-prompt: .asciiz "Enter a number: "
-result: .asciiz "Sum from 1 to N is: "
-newline:.asciiz "\n"
-
-        .text
-        .globl main
-main:
-        li      $v0, 4              # syscall: print_string
-        la      $a0, prompt
-        syscall
-
-        li      $v0, 5              # syscall: read_int
-        syscall
-        move    $t0, $v0            # N
-
-        li      $t1, 0              # sum
-        li      $t2, 1              # i
-loop:
-        bgt     $t2, $t0, done
-        add     $t1, $t1, $t2
-        addi    $t2, $t2, 1
-        j       loop
-
-done:
-        li      $v0, 4
-        la      $a0, result
-        syscall
-
-        li      $v0, 1              # syscall: print_int
-        move    $a0, $t1
-        syscall
-
-        li      $v0, 4
-        la      $a0, newline
-        syscall
-
-        li      $v0, 10             # syscall: exit
-        syscall
-```
-
-## Architecture
-
-The codebase is organized into two clearly separated layers. The simulator core has no UI dependencies and is fully unit-testable. The React UI layer consumes the core through a small set of hooks.
-
-```
-webmars/
-  src/
-    core/         Lexer, parser, two-pass assembler, instruction
-                  definitions, register file, memory model, simulator,
-                  syscall handler. Pure TypeScript. No React imports.
-    ui/           Layout, control bar, source editor, register and
-                  memory panels, console, theme. Imports from core.
-    hooks/        Zustand store and the glue connecting ui to core
-                  (useSimulator, useAssembler, useTheme).
-    examples/     Canonical MIPS example programs.
-  tests/          Vitest unit tests for the assembler and simulator,
-                  plus golden-program integration tests.
-  docs/           PRD, design notes, instruction reference.
-```
-
-The dependency direction is enforced: `ui/` imports from `core/`, never the reverse. This keeps the simulator independently testable and lets the UI evolve without risk to the execution model.
-
-### Tech stack
-
-| Layer | Technology |
-| --- | --- |
-| Framework | React 19 with TypeScript 6 (strict, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`) |
-| Build tool | Vite 8 |
-| Styling | Tailwind CSS v4 (via `@tailwindcss/vite`), CSS custom properties for theme tokens |
-| Editor | Monaco Editor (`@monaco-editor/react`) with a custom MIPS Monarch grammar |
-| State | Zustand |
-| Testing | Vitest |
-| CI | GitHub Actions |
-| Hosting | Vercel (or GitHub Pages) |
-
-## Testing
+### Available scripts
 
 ```bash
-npm run test          # run the unit and integration tests once
-npm run test:watch    # run in watch mode
-npm run typecheck     # strict TypeScript check, no emit
+npm run dev          # start dev server with HMR
+npm run build        # production build to dist/
+npm run preview      # serve the production build locally
+npm run typecheck    # strict TypeScript check (no emit)
+npm run lint         # ESLint across src/ and tests/
+npm run test         # run Vitest once
+npm run test:watch   # Vitest in watch mode
 ```
 
-The test suite includes:
+### Architecture
 
-- Unit tests for the lexer, parser, and assembler.
-- Per-instruction simulator tests covering correct semantics, sign extension, and edge cases.
-- Golden-program integration tests that assemble and run canonical MIPS programs and verify final register, memory, and console state against expected output.
+```
+src/
+  core/        Lexer, parser, two-pass assembler, instruction
+               definitions, register file, memory, simulator,
+               syscall handler. Pure TypeScript. No React imports.
+  hooks/       Zustand store and the glue between ui and core.
+  ui/          IDE shell, all panels and dialogs.
+  landing/    /about marketing landing page (lazy-loaded).
+  lib/         Router, file I/O, MIPS Monarch grammar, constants.
+  examples/    Bundled .asm starter programs.
+tests/         Vitest unit and golden-program integration tests.
+docs/          PRD, final report, demo script, deploy notes.
+```
 
-Cross-checking simulator output against the original MARS for the same input is part of our verification process. Any discrepancy is treated as a bug in WebMARS unless it is the result of a feature explicitly listed as out of scope.
+The dependency direction is enforced: `ui/` imports from `core/`,
+never the reverse. The simulator core has no UI dependencies and is
+fully unit-testable. Routing is a 30-line History API wrapper in
+`src/lib/router.ts` — no router library.
 
-## Supported Instruction Set
+The full instruction-set reference (~50 instructions across R/I/J,
+FPU single-precision, and trap families, plus pseudo-instructions
+and syscalls) is available in-app via the `F1` Help dialog. See
+[`docs/PRD.md`](./docs/PRD.md) for the architecture deep-dive and
+the explicit out-of-scope list (double-precision FPU, coprocessor 0,
+pipeline / cache modeling, `.include` / macros, multi-file assembly,
+`html2canvas`-style screen magnification).
 
-**Arithmetic and logical:** `add`, `addu`, `sub`, `subu`, `addi`, `addiu`, `and`, `or`, `xor`, `nor`, `andi`, `ori`, `xori`, `sll`, `srl`, `sra`, `sllv`, `srlv`, `srav`, `slt`, `slti`, `sltu`, `sltiu`, `mult`, `multu`, `div`, `divu`, `mfhi`, `mflo`, `mthi`, `mtlo`, `lui`.
+### Contributing
 
-**Memory:** `lw`, `sw`, `lh`, `lhu`, `sh`, `lb`, `lbu`, `sb`.
+This is a course project; external contributions aren't accepted
+until v2.0. Bug reports via GitHub Issues are welcome.
 
-**Branch and jump:** `beq`, `bne`, `bgtz`, `bltz`, `blez`, `bgez`, `j`, `jal`, `jr`, `jalr`.
+If you fork: open a pull request against `main`. Run `typecheck`,
+`lint`, and `test` before pushing — CI runs all three on every push.
+Conventional Commits style for messages (`feat:`, `fix:`, `docs:`,
+`refactor:`, `chore:`, `test:`).
 
-**Trap (Phase 2F):** `teq`, `tne`, `tlt`, `tltu`, `tge`, `tgeu`. Each raises a runtime error when its condition holds.
-
-**FPU — coprocessor 1, single-precision (Phase 2B):** `add.s`, `sub.s`, `mul.s`, `div.s`, `sqrt.s`, `abs.s`, `mov.s`, `neg.s`, `cvt.s.w`, `cvt.w.s`, `c.eq.s`, `c.lt.s`, `c.le.s`, `bc1f`, `bc1t`, `mtc1`, `mfc1`, `lwc1`, `swc1`. The FPU panel in the right inspector is gated behind a settings toggle.
-
-**Pseudo-instructions:** `li`, `la`, `move`, `blt`, `ble`, `bgt`, `bge`, `abs`, `sge`, `sgt`, `neg`, `not`, `nop`.
-
-**Syscalls:** `1` (print int), `4` (print string), `5` (read int), `8` (read string), `10` (exit), `11` (print char), `12` (read char), `30` (system time), `32` (sleep), `41` (random int), `42` (random int range), `50` (confirm dialog), `51` (input int dialog), `53` (input string dialog), `54` (message dialog).
-
-## Limitations
-
-WebMARS is intentionally scoped. The following are known limitations of v1.1.0 and are not bugs.
-
-- Tools menu coverage is partial: Instruction Counter, Bitmap Display, Keyboard / Display MMIO, Floating-Point Representation, Memory Reference Visualization, and Screen Magnifier ship as real tools. Cache Simulator, MIPS X-Ray, BHT Simulator, Digital Lab Sim, Scavenger Hunt, and Mars Bot ship as placeholder modals describing the v2.0 plan.
-- No `.include` or macros, and no multi-file projects in the assembler sense — multi-file is editor-only.
-- FPU support is single-precision only. Double-precision (`.d` ops) and coprocessor 0 (`$status`, `$cause`, `$epc`, `mfc0`/`mtc0`/`eret`) are out of scope.
-- Branch-delay-slot semantics are off by default for teaching clarity. Real-MIPS delay-slot behavior can be opted into via Settings → Simulator → "Delayed branching"; when on, `jal`/`jalr` save PC+8 to skip the delay slot.
-- Self-modifying code is rejected by default (any store into the `.text` segment throws). Settings → Simulator → "Self-modifying code allowed" lifts the guard.
-- Pipeline timing, hazards, forwarding, and cache effects are not modeled. Instruction execution is sequential and atomic.
-- The `Confirm` dialog syscall (50) collapses MARS's three-state response (Yes / No / Cancel) to two states (OK → Yes, Cancel → No) because it uses the native `window.confirm`.
-- The Screen Magnifier renders a positioned overlay rectangle but does not currently mirror the underlying pixels at 2x. Full DOM-cloning magnification needs `html2canvas` or similar; out of scope for v1.1.0. Use the OS-level zoom for projector demos in the meantime.
-- Browser persistence is `localStorage`-only — layout, theme, recent files, breakpoints, and run speed survive a reload, but source code itself is not auto-saved. Use File → Save (or `Ctrl+S`) before closing the tab.
-- The File System Access API used for native Open / Save is Chromium-only. Firefox falls back to `<input type="file">` and a blob download.
-
-## Contributing
-
-This project is being developed as a final project for a single course and is not currently accepting external contributions. Once v1.0 ships, that policy may change.
-
-If you find a bug or have a suggestion, please open an issue.
-
-### Commit conventions
-
-We use [Conventional Commits](https://www.conventionalcommits.org/). Common prefixes:
-
-- `feat:` a new feature.
-- `fix:` a bug fix.
-- `docs:` documentation only.
-- `test:` adding or correcting tests.
-- `refactor:` code change that neither fixes a bug nor adds a feature.
-- `chore:` tooling, CI, dependency updates.
-
-### Branching
-
-Feature branches are cut from `main` and merged via pull request. CI must pass before merge.
+---
 
 ## Team
 
-| Name | Role |
-| --- | --- |
-| Landon Clay | Assembler and parser |
-| Zachary Gass | Simulator and execution |
-| Bryan Djenabia | UI, integration, and deployment |
+Three engineers built this in 2026:
 
-## Acknowledgements
-
-WebMARS is inspired by, and built as a tribute to, the original MARS simulator developed by Pete Sanderson and Kenneth Vollmar. We are not affiliated with the original project. Their work has supported MIPS assembly education for over two decades and remains the standard against which we measure correctness.
-
-## AI tools used
-
-This project was developed with the assistance of Claude Code
-(Anthropic), used as a code-generation and pair-programming tool.
-
-The development pattern was: I authored the project plan, the PRD,
-the architecture decisions, the design tokens, the multi-agent
-execution prompts, and the review of every change before it landed
-on a branch. Claude Code generated the corresponding implementation
-under those instructions and committed on my behalf.
-
-All commits in this repository are authored under my git identity
-because I planned, directed, reviewed, and accept responsibility for
-the work. This disclosure exists so that the use of AI tooling is
-part of the public record of the project.
-
-Where Claude Code's contribution is meaningful enough to credit
-specifically, individual commit messages or pull request bodies note
-it. The full Day 1 plan and execution prompts that drove the AI-
-generated portions are tracked in `docs/` for transparency.
+- **Bryan Djenabia** — UI, integration, deployment
+- **Landon Clay** — Assembler and parser
+- **Zachary Gass** — Simulator and execution
 
 ## License
 
 MIT. See [LICENSE](./LICENSE) for the full text.
+
+## Acknowledgements
+
+Inspired by [MARS](https://courses.missouristate.edu/KenVollmar/MARS/)
+by Pete Sanderson and Kenneth Vollmar at Missouri State University.
+WebMARS is an independent re-implementation, not a fork. Their work
+has supported MIPS education for over two decades and remains the
+standard we verify correctness against.
+
+## AI tools used
+
+This project was developed with the assistance of Claude Code
+(Anthropic) as a code-generation and pair-programming tool. The
+development pattern: I authored the PRD, architecture decisions,
+design tokens, and multi-agent execution prompts; Claude Code
+generated the corresponding implementation under those instructions
+and committed on my behalf. All commits are authored under my git
+identity because I planned, directed, reviewed, and accept
+responsibility for the work. The Day 1 plan and execution prompts
+are tracked in `docs/` for transparency.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,22 @@
-import LandingPage from '@/landing/LandingPage.tsx'
+import { Suspense, lazy } from 'react'
 import { useRoute } from '@/lib/router.ts'
 import { Shell } from '@/ui/Shell.tsx'
+
+// Lazy-load the landing page so the IDE bundle isn't burdened with
+// marketing CSS for the default route. Users who deep-link to / get the
+// IDE at full speed; only /about visitors pay the landing bundle cost
+// (and only once — Vite hashes the chunk).
+const LandingPage = lazy(() => import('@/landing/LandingPage.tsx'))
 
 export default function App() {
   const route = useRoute()
 
   if (route === 'landing') {
-    return <LandingPage />
+    return (
+      <Suspense fallback={<div className="h-dvh w-full bg-surface-0" />}>
+        <LandingPage />
+      </Suspense>
+    )
   }
 
   return <Shell />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,13 @@
+import LandingPage from '@/landing/LandingPage.tsx'
+import { useRoute } from '@/lib/router.ts'
 import { Shell } from '@/ui/Shell.tsx'
 
 export default function App() {
+  const route = useRoute()
+
+  if (route === 'landing') {
+    return <LandingPage />
+  }
+
   return <Shell />
 }

--- a/src/landing/Hero.tsx
+++ b/src/landing/Hero.tsx
@@ -84,7 +84,7 @@ export function Hero() {
 
           {/* Trust signals — real numbers only */}
           <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-2 text-[14px]" style={{ color: 'var(--l-ink-2)' }}>
-            <span>100+ tests passing</span>
+            <span>125+ tests passing</span>
             <span aria-hidden="true">·</span>
             <span>MIT licensed</span>
             <span aria-hidden="true">·</span>


### PR DESCRIPTION
## Summary
Phase 4.5 — wires the router into App.tsx so /about renders the landing page, polishes one trust-signal inconsistency on the landing hero, and splits the 319-line README into two cleanly-separated sections (Usage for students, Self-installation for developers).

## What changed

### SA-1 — landing page route now actually serves
- `src/App.tsx` previously mounted `<Shell />` unconditionally; the router layer in `src/lib/router.ts` was dead code. Now App reads `useRoute()` and renders `<LandingPage />` when `route === 'landing'`.
- `LandingPage` is loaded via `React.lazy` so the marketing chunk (~10.6 kB gzipped) doesn't ship on the IDE's default route. Suspense fallback is a blank surface in the IDE's color so the ~50 ms of bundle-load on first /about visit doesn't flash white.
- Bundle impact (gzipped): main IDE 126.70 → 116.94 kB (-9.76 kB); new LandingPage chunk 10.62 kB; new LandingPage CSS 0.71 kB.

### SA-2 — landing UX static audit + one fix
- All 9 section components reviewed. Section IDs (`#features`, `#showcase`, `#personas`, `#team`) match Nav anchors. All external links use `target="_blank"` + `rel="noopener noreferrer"`. All "Open the editor" buttons go through `navigate('/')`. Skip-link, semantic landmarks (header/main/footer), `aria-label`, `aria-labelledby`, `aria-hidden`, focus-visible rings, mobile hamburger, and scroll-triggered reveal are all in place.
- **Fix:** Hero trust-signal said `100+ tests passing`; ProofBar/Showcase/Personas all said `125+`. Hero now matches.
- Verified `docs/PRD.md` and `docs/FINAL_REPORT.md` exist on master so the linked-from-landing footer references resolve.
- Manual checks **still recommended on the deployed Vercel build** — see "Test plan" below.

### SA-3 — README split (319 → 192 lines)
- Two clearly-marked sections separated by horizontal rules:
  1. **Getting started (Usage)** — first program, common workflows, full keyboard-shortcut table, browser support
  2. **Self-installation (Developers)** — prerequisites, setup, scripts, directory layout, contribution conventions
- Removed: repetitive feature listings (landing covers them), the full instruction-set table (in-app F1 Help dialog covers it), the long architecture deep-dive (links to `docs/PRD.md`), verbose `cd` / `git clone` explanations.
- Preserved: team credits, MIT license, MARS attribution, AI-tools transparency disclosure.
- Updated test count from 119/103 (two stale spots) to actual 125. GitHub URL updated to canonical `Webmarssimulator/WebMARS` (matches `src/lib/constants.ts`).

## Test plan

### Programmatic (run on the branch — all passing)
- [x] `npm run typecheck` → 0 errors
- [x] `npm run test` → **125 / 125 passing** (14 test files)
- [x] `npm run lint` → 0 errors, 0 warnings
- [x] `npm run build` → clean; lazy-loaded LandingPage chunk visible in `dist/assets`

### Manual (please walk through after merge on the live Vercel deploy)
**SA-1 routing verification:**
- [ ] Visit https://www.webmarsimulator.com/ → IDE renders
- [ ] Visit https://www.webmarsimulator.com/about → landing renders
- [ ] Click "About" in the IDE menu bar → URL changes to /about, landing renders, no full reload
- [ ] Browser back → returns to / showing IDE
- [ ] Browser forward → returns to /about showing landing
- [ ] Refresh on /about → still shows landing (Vercel rewrite + SPA boot detection)

**SA-2 landing UX (eyeball, not all listed exhaustively):**
- [ ] Center anchor links scroll smoothly to their sections
- [ ] Sticky nav gets blur background after 80 px scroll
- [ ] Mobile (≤768 px) shows hamburger overlay with all nav items
- [ ] FinalCTA "Copy" button copies the live URL to clipboard
- [ ] No console errors / warnings / 404s
- [ ] Tab order is logical from top to bottom; focus rings visible
- [ ] Renders cleanly at 1920 / 1280 / 1024 / 768 / 375 px

After merge, /about will serve the landing page on the live Vercel deploy.
