### PR TITLE
agent-02: typed API client, sonner toasts, env-aware base URL

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,7 @@
+# Copy to .env.local for local development. Vite exposes VITE_-prefixed
+# variables to the client bundle at build time.
+
+# Base URL of the WebMARS API (webmars-api).
+#   Local backend:  http://localhost:8080
+#   Production:     https://webmars-api-production.up.railway.app
+VITE_API_BASE=http://localhost:8080

--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -158,7 +158,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   AGENT 01 — PDF Ingestion & Requirements Extraction ............ ✅ COMPLETE
 
   ── DYNAMIC IMPLEMENTATION AGENTS (inserted by AGENT 01) ──────────────────────
-  AGENT 02 — API Client, Toast System & Env-Aware Base URL ...... ⬜ NOT STARTED
+  AGENT 02 — API Client, Toast System & Env-Aware Base URL ...... ✅ COMPLETE
   AGENT 03 — Editor Persistence Across Refresh .................. ⬜ NOT STARTED
   AGENT 04 — Monaco Light Theme + System Preference ............. ⬜ NOT STARTED
   AGENT 05 — rem Pseudo-Instruction (Assembler + Tests) ......... ⬜ NOT STARTED
@@ -206,7 +206,16 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   https://webmars-api-production.up.railway.app (200 verified); frontend
   live on Vercel without integration; no Docker/Postgres locally →
   Testcontainers suite authored but not locally executable. G10 ambiguity
-  flags: REQ-001/002/014/015/017. PR #41.
+  flags: REQ-001/002/014/015/017. PR #41 merged, main @ fff16a8.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 02: API client + toasts + env base (REQ-007/018/020)
+  done. src/lib/api.ts typed against the REAL upstream serialization (owner
+  ={username}, MostRun.snippetTitle, Page envelope — plan skeleton
+  corrected); sonner Toaster at App root, theme-aware; .env.local.example.
+  5 new api tests; 130/130 green; typecheck/lint/build exit 0; bundle
+  450.46 kB (+33 kB sonner). Note: upstream RunController ALREADY has the
+  audit-C2 visibility check — AGENT 12 scope shrinks to PUT endpoint +
+  Testcontainers. PR #42.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -725,7 +734,27 @@ APPENDIX A-01 — PDF Ingestion & Requirements Extraction
     note by AGENT 02's commit)
 --------------------------------------------------------------------------------
 APPENDIX A-02 — API Client, Toast System & Env-Aware Base URL
-  STATUS: / DATE: / PER-REQ (007/018/020): / BUILD+TEST: / PR #:
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  REQ-007: IMPLEMENTED — sonner added to package.json; <Toaster/> mounted
+    in src/App.tsx (theme-aware: follows app theme, hc maps to dark;
+    bottom-right, closeButton, richColors). Renders on both desktop and
+    mobile shell paths (mounted beside <Shell/> at the App root).
+  REQ-018: IMPLEMENTED — src/lib/api.ts:6 BASE = import.meta.env.VITE_API_BASE
+    ?? 'http://localhost:8080'; .env.local.example at repo root documents
+    local + production values (SF6).
+  REQ-020: IMPLEMENTED — src/lib/api.ts: ApiError(status/body), authHeader()
+    from webmars.token (privacy-mode safe try/catch), request<T> with JSON
+    headers + 204 handling; register/login/getSnippet/getMySnippets/
+    getPublicSnippets/saveSnippet/updateSnippet/deleteSnippet/logRun/
+    getRecentRuns/getMostRunPrograms. Types corrected to the ACTUAL
+    upstream serialization (owner={username} only, MostRun.snippetTitle,
+    Spring Page envelope for /mine and /public) rather than the plan's
+    guessed shapes. src/tests/api.test.ts: 5 tests (auth header on/off,
+    ApiError status/body, JSON write bodies, 204 → undefined).
+  BUILD+TEST: npm run typecheck → exit 0; npm run lint → exit 0; npm run
+    build → exit 0 (bundle 450.46 kB / gzip 125.74 kB; +33 kB = sonner);
+    npm test → 130/130 pass (15 files).
+  PR # / MAIN COMMIT: PR #42.
 --------------------------------------------------------------------------------
 APPENDIX A-03 — Editor Persistence
   STATUS: / DATE: / PER-REQ (001): / BUILD+TEST: / PR #:
@@ -779,7 +808,7 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-004 | p.8 §2.4 | Backend: login failures return 401 'Invalid credentials' (same msg both cases) | FIX | A12 | ⬜ | | pre-exists upstream (verify)
   REQ-005 | p.8-9 §2.5; p.38 §7.1; p.56 §10.1 | Backend secrets: env-var indirection, .env.example, .gitignore, rotation, git-history scrub + force-push + re-clone | SECURITY | A12 | ⬜ | | partial upstream; rotation/scrub = owner
   REQ-006 | p.9 §2.6; p.46-48 §8.2 | ScreenMagnifier rewrite: DOM-clone loupe 240x160 @2x, hint state, Escape, no per-mousemove reclone, Monaco excluded | FEATURE | A06 | ⬜ | |
-  REQ-007 | p.10 §2.7; p.20 D1 | Toast system via sonner; Toaster at App root; error/success toasts for API calls | UI/UX | A02 | ⬜ | |
+  REQ-007 | p.10 §2.7; p.20 D1 | Toast system via sonner; Toaster at App root; error/success toasts for API calls | UI/UX | A02 | IMPLEMENTED | #42 | src/App.tsx (Toaster mount); A-02
   REQ-008 | p.10 §2.8 | Loading state on every async button: disabled + spinner/label while in flight; no duplicate submits | UI/UX | A90 | ⬜ | | implemented inline by A07-A10; A90 sweeps
   REQ-009 | p.10-11 §2.9; p.36 §6.6; p.23 D5 | ?snippet=<id> on boot loads snippet into editor; 404 → toast + default example; document title updated | FEATURE | A08 | ⬜ | |
   REQ-010 | p.11 §2.10; p.26 D8 | JWT expiry 8h (sprint choice) + README v1.3 note re refresh tokens | FIX | A12 | ⬜ | | 8h pre-exists (verify note)
@@ -790,9 +819,9 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-015 | p.12 §3.2; p.49-51 §8.4; p.53 §9.1 | Testcontainers integration tests: PostgresTestBase + Auth/Snippet/Run/JwtUtil test classes per §9.1 scenario table | TEST | A12 | ⬜ | | MISSING upstream → fork PR; not executable locally (SF4)
   REQ-016 | p.13 §3.3 | Backend .env.example documents required vars; .gitignore excludes .env | INFRA | A12 | ⬜ | | pre-exists (verify)
   REQ-017 | p.15-16 §3.6.1; p.27-28 D10 | Backend deployed w/ env vars + Flyway migrations + JPA validate [Render→Railway substitution made by team] | INFRA | A92 | ⬜ | | live (verify + record)
-  REQ-018 | p.16 §3.6.2; p.20 D1 | Frontend env-aware API base: VITE_API_BASE w/ localhost fallback; .env.local.example | INFRA | A02 | ⬜ | |
+  REQ-018 | p.16 §3.6.2; p.20 D1 | Frontend env-aware API base: VITE_API_BASE w/ localhost fallback; .env.local.example | INFRA | A02 | IMPLEMENTED | #42 | src/lib/api.ts:6; .env.local.example
   REQ-019 | p.16 §3.6.2; p.27 D10; p.56 §10.1 | Vercel env var VITE_API_BASE set + production redeploy + deployed-combo CORS check | INFRA | A92 | ⬜ | | dashboard = owner unless CLI authed
-  REQ-020 | p.30-32 §6.1 | src/lib/api.ts typed client: ApiError, authHeader, request<T> w/ 204, full auth/snippets/runs surface per skeleton | FEATURE | A02 | ⬜ | |
+  REQ-020 | p.30-32 §6.1 | src/lib/api.ts typed client: ApiError, authHeader, request<T> w/ 204, full auth/snippets/runs surface per skeleton | FEATURE | A02 | IMPLEMENTED | #42 | src/lib/api.ts; src/tests/api.test.ts (5 tests)
   REQ-021 | p.34-35 §6.4; p.22 D4 | Auth slice (webmars.token/webmars.username) + AuthModal (tabs, busy, 401/409/429/network msg map) + toolbar Sign-in/username/Log-out | FEATURE | A07 | ⬜ | |
   REQ-022 | p.36 §6.5; p.23 D5 | Save-to-Account + ShareModal: create-vs-update semantics, copy link + toast, visibility shown + toggle → PUT | FEATURE | A08 | ⬜ | |
   REQ-023 | p.44-45 §7.7; p.22-24 D4-D5 | rem pseudo-instruction: lexer mnemonic, parser ["R","R","R"], assembler div+mfhi expansion | FEATURE | A05 | ⬜ | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "webmars",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webmars",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@monaco-editor/react": "^4.7.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "sonner": "^2.0.7",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -4386,6 +4387,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@monaco-editor/react": "^4.7.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "sonner": "^2.0.7",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { Suspense, lazy } from 'react'
+import { Toaster } from 'sonner'
 import { useRoute } from '@/lib/router.ts'
 import { Shell } from '@/ui/Shell.tsx'
+import { useSimulator } from '@/hooks/useSimulator.ts'
 
 // Lazy-load the landing page so the IDE bundle isn't burdened with
 // marketing CSS for the default route. Users who deep-link to / get the
@@ -10,6 +12,11 @@ const LandingPage = lazy(() => import('@/landing/LandingPage.tsx'))
 
 export default function App() {
   const route = useRoute()
+  const theme = useSimulator((s) => s.theme)
+
+  // Sonner only knows light/dark; the high-contrast shell keeps the
+  // dark toast styling.
+  const toasterTheme = theme === 'light' ? 'light' : 'dark'
 
   if (route === 'landing') {
     return (
@@ -19,5 +26,10 @@ export default function App() {
     )
   }
 
-  return <Shell />
+  return (
+    <>
+      <Shell />
+      <Toaster theme={toasterTheme} position="bottom-right" closeButton richColors />
+    </>
+  )
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,161 @@
+// Typed HTTP client for the WebMARS API (webmars-api). Every part of the
+// UI talks to the backend through this module — no raw fetch calls
+// anywhere else in src/. Centralizes the auth header, error handling,
+// and the environment-configurable base URL.
+
+const BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8080'
+
+export const TOKEN_STORAGE_KEY = 'webmars.token'
+export const USERNAME_STORAGE_KEY = 'webmars.username'
+
+/** Non-2xx responses surface as ApiError so callers can distinguish
+ *  401 (bad credentials), 404 (missing/private), 409 (conflict), 429
+ *  (rate limited) and 5xx without string-matching messages. */
+export class ApiError extends Error {
+  readonly status: number
+  readonly body: string
+
+  constructor(status: number, body: string) {
+    super(`HTTP ${status}: ${body || '(no body)'}`)
+    this.name = 'ApiError'
+    this.status = status
+    this.body = body
+  }
+}
+
+function readToken(): string | null {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage.getItem(TOKEN_STORAGE_KEY)
+  } catch {
+    // localStorage can throw under privacy mode — treat as signed out.
+    return null
+  }
+}
+
+function authHeader(): Record<string, string> {
+  const t = readToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+      ...(init?.headers ?? {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new ApiError(res.status, body)
+  }
+  if (res.status === 204) return undefined as T
+  return res.json() as Promise<T>
+}
+
+// ── Auth ──────────────────────────────────────────────────────────
+
+export interface RegisterResponse {
+  message: string
+  username: string
+}
+export interface LoginResponse {
+  token: string
+}
+
+export const register = (username: string, password: string) =>
+  request<RegisterResponse>('/auth/register', {
+    method: 'POST',
+    body: JSON.stringify({ username, password }),
+  })
+
+export const login = (username: string, password: string) =>
+  request<LoginResponse>('/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ username, password }),
+  })
+
+// ── Snippets ──────────────────────────────────────────────────────
+
+export type Visibility = 'PUBLIC' | 'PRIVATE'
+
+/** Owner as serialized by the API — only the username survives
+ *  (@JsonIgnoreProperties hides id/password/createdAt). */
+export interface SnippetOwner {
+  username: string
+}
+
+export interface Snippet {
+  id: number
+  title: string | null
+  code: string
+  owner: SnippetOwner | null
+  visibility: Visibility
+  createdAt: string
+  updatedAt: string
+}
+
+/** Spring Data page envelope, as returned by /snippets/mine and
+ *  /snippets/public. */
+export interface Page<T> {
+  content: T[]
+  totalPages: number
+  totalElements: number
+  number: number
+  first: boolean
+  last: boolean
+}
+
+export const getSnippet = (id: number) => request<Snippet>(`/snippets/${id}`)
+
+export const getMySnippets = (page = 0, size = 20) =>
+  request<Page<Snippet>>(`/snippets/mine?page=${page}&size=${size}`)
+
+export const getPublicSnippets = (page = 0, size = 20) =>
+  request<Page<Snippet>>(`/snippets/public?page=${page}&size=${size}`)
+
+export const saveSnippet = (body: { title: string; code: string; visibility?: Visibility }) =>
+  request<Snippet>('/snippets/save', { method: 'POST', body: JSON.stringify(body) })
+
+export const updateSnippet = (
+  id: number,
+  body: Partial<{ title: string; code: string; visibility: Visibility }>,
+) => request<Snippet>(`/snippets/${id}`, { method: 'PUT', body: JSON.stringify(body) })
+
+export const deleteSnippet = (id: number) =>
+  request<void>(`/snippets/${id}`, { method: 'DELETE' })
+
+// ── Runs ──────────────────────────────────────────────────────────
+
+export type ExitStatus = 'COMPLETED' | 'ERROR' | 'PAUSED' | 'ABORTED'
+
+export interface Run {
+  id: number
+  snippetId: number
+  snippetTitle: string | null
+  startedAt: string
+  durationMs: number | null
+  instructionsExecuted: number | null
+  exitStatus: ExitStatus
+}
+
+export interface MostRun {
+  snippetId: number
+  snippetTitle: string | null
+  runCount: number
+  lastRun: string
+}
+
+export const logRun = (body: {
+  snippetId: number
+  durationMs?: number
+  instructionsExecuted?: number
+  exitStatus: ExitStatus
+  errorMessage?: string
+}) => request<Run>('/runs', { method: 'POST', body: JSON.stringify(body) })
+
+export const getRecentRuns = (limit = 20) => request<Run[]>(`/runs/recent?limit=${limit}`)
+
+export const getMostRunPrograms = (limit = 10) =>
+  request<MostRun[]>(`/runs/most-run?limit=${limit}`)

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as api from '../lib/api'
+
+// The vitest config runs in a node environment: `window` is undefined
+// until stubbed. Each test that needs an auth token stubs a minimal
+// window.localStorage; fetch is stubbed per-test to capture the request.
+
+function stubToken(token: string | null) {
+  vi.stubGlobal('window', {
+    localStorage: {
+      getItem: (key: string) => (key === api.TOKEN_STORAGE_KEY ? token : null),
+    },
+  })
+}
+
+function stubFetch(status: number, body: unknown): ReturnType<typeof vi.fn> {
+  const fn = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('api client', () => {
+  it('attaches the Authorization header when a token exists', async () => {
+    stubToken('abc.def.ghi')
+    const fetchMock = stubFetch(200, [])
+
+    await api.getRecentRuns()
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer abc.def.ghi')
+  })
+
+  it('omits the Authorization header when no token exists', async () => {
+    stubToken(null)
+    const fetchMock = stubFetch(200, { content: [] })
+
+    await api.getPublicSnippets()
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined()
+  })
+
+  it('throws ApiError with the response status on non-2xx', async () => {
+    stubToken(null)
+    stubFetch(401, 'Invalid credentials')
+
+    const err = await api.login('user', 'wrong').catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(api.ApiError)
+    expect((err as api.ApiError).status).toBe(401)
+    expect((err as api.ApiError).body).toBe('Invalid credentials')
+  })
+
+  it('sends JSON bodies with Content-Type on writes', async () => {
+    stubToken('tkn')
+    const fetchMock = stubFetch(200, { id: 1 })
+
+    await api.saveSnippet({ title: 'T', code: 'li $t0, 1', visibility: 'PUBLIC' })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/snippets/save')
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    expect(JSON.parse(init.body as string)).toEqual({
+      title: 'T',
+      code: 'li $t0, 1',
+      visibility: 'PUBLIC',
+    })
+  })
+
+  it('resolves undefined for 204 responses', async () => {
+    stubToken('tkn')
+    stubFetch(204, '')
+
+    await expect(api.deleteSnippet(7)).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Agent
AGENT 02 - API Client, Toast System and Env-Aware Base URL (loop position: 3 of 18)

## Requirements delivered
- REQ-007 - sonner toast system, Toaster at App root (src/App.tsx)
- REQ-018 - VITE_API_BASE env-aware base URL + .env.local.example
- REQ-020 - src/lib/api.ts typed HTTP client + 5 unit tests

## What changed and why
Foundation layer for all v1.2 account features. The client types were verified against the ACTUAL upstream webmars-api serialization (owner serializes as {username} only; /mine and /public return Spring Page envelopes; MostRun uses snippetTitle) rather than the plan's guessed shapes, so downstream agents build on reality.

## Evidence summary
- Build: npm run build -> exit 0 (450.46 kB, +33 kB sonner)
- Tests: npm test -> 130/130 (5 new in src/tests/api.test.ts)
- Typecheck + lint: exit 0

## Out of scope / follow-ups
Upstream RunController already includes the audit-C2 visibility check - AGENT 12 scope reduced accordingly.