### PR TITLE
agent-03: persist editor source across refresh

### DIFF
--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -159,7 +159,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
 
   ── DYNAMIC IMPLEMENTATION AGENTS (inserted by AGENT 01) ──────────────────────
   AGENT 02 — API Client, Toast System & Env-Aware Base URL ...... ✅ COMPLETE
-  AGENT 03 — Editor Persistence Across Refresh .................. ⬜ NOT STARTED
+  AGENT 03 — Editor Persistence Across Refresh .................. ✅ COMPLETE
   AGENT 04 — Monaco Light Theme + System Preference ............. ⬜ NOT STARTED
   AGENT 05 — rem Pseudo-Instruction (Assembler + Tests) ......... ⬜ NOT STARTED
   AGENT 06 — Tools: Bitmap Grid Sizes + Screen Magnifier ........ ⬜ NOT STARTED
@@ -215,7 +215,13 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   5 new api tests; 130/130 green; typecheck/lint/build exit 0; bundle
   450.46 kB (+33 kB sonner). Note: upstream RunController ALREADY has the
   audit-C2 visibility check — AGENT 12 scope shrinks to PUT endpoint +
-  Testcontainers. PR #42.
+  Testcontainers. PR #42 merged, main @ 4ac89d2.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 03: editor persistence (REQ-001) done. Workspace
+  (files + active tab) persists to webmars:workspace-v1, debounced 250ms
+  with beforeunload flush; hydrates on boot; simulator state provably
+  excluded (payload keys asserted in test). 4 new tests; 134/134 green;
+  typecheck/lint/build exit 0. PR #43.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -757,7 +763,22 @@ APPENDIX A-02 — API Client, Toast System & Env-Aware Base URL
   PR # / MAIN COMMIT: PR #42.
 --------------------------------------------------------------------------------
 APPENDIX A-03 — Editor Persistence
-  STATUS: / DATE: / PER-REQ (001): / BUILD+TEST: / PR #:
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  REQ-001: IMPLEMENTED — src/hooks/useSimulator.ts: readPersistedWorkspace/
+    writePersistedWorkspace (key webmars:workspace-v1, validated parse,
+    privacy-mode-safe try/catch per existing convention); initialFiles/
+    activeFileId/source hydrate from the persisted workspace; store
+    subscription persists {files(id,name,source,modified), activeFileId}
+    debounced 250ms + beforeunload flush. Simulator state excluded by
+    construction — payload keys asserted to be exactly [activeFileId,
+    files] in test. FileSystemFileHandle rehydrates as null. Mechanism
+    follows the store's manual per-key convention, not persist middleware
+    (G10 note in A-01) — behavioral acceptance identical.
+    src/tests/persist.test.ts: 4 tests (debounced write, rehydration,
+    no simulator state, corrupt-payload fallback).
+  BUILD+TEST: typecheck 0 / lint 0 / build exit 0 / vitest 134/134 (16
+    files). Live-browser refresh walk deferred to A91 Q1.
+  PR # / MAIN COMMIT: PR #43.
 --------------------------------------------------------------------------------
 APPENDIX A-04 — Monaco Light Theme + System Preference
   STATUS: / DATE: / PER-REQ (002): / BUILD+TEST: / PR #:
@@ -802,7 +823,7 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
 
   ID      | PDF PAGE/SECTION | SUMMARY | CATEGORY | OWNER | STATUS | PR # | EVIDENCE
   --------|------------------|---------|----------|-------|--------|------|---------
-  REQ-001 | p.5-6 §2.1; p.32 §6.2 | Persist editor source/files/activeFileId across refresh; simulator state NOT persisted; private-mode safe; last-write-wins OK [mechanism per codebase convention, SF5] | FIX | A03 | ⬜ | |
+  REQ-001 | p.5-6 §2.1; p.32 §6.2 | Persist editor source/files/activeFileId across refresh; simulator state NOT persisted; private-mode safe; last-write-wins OK [mechanism per codebase convention, SF5] | FIX | A03 | IMPLEMENTED | #43 | useSimulator.ts workspace helpers + subscribe; persist.test.ts (4 tests)
   REQ-002 | p.6-7 §2.2; p.33-34 §6.3 | Monaco webmars-light theme; theme preference incl. 'system' w/ live OS tracking; SettingsDialog picker; shell+editor stay in sync [hc keeps dark Monaco] | FIX | A04 | ⬜ | |
   REQ-003 | p.7-8 §2.3 | Backend: DELETE /snippets/{id} owner check, 404 to non-owners | SECURITY | A12 | ⬜ | | pre-exists upstream (verify)
   REQ-004 | p.8 §2.4 | Backend: login failures return 401 'Invalid credentials' (same msg both cases) | FIX | A12 | ⬜ | | pre-exists upstream (verify)

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -285,6 +285,56 @@ function makeFileId(): string {
   return `file-${Date.now()}-${Math.floor(Math.random() * 1000)}`
 }
 
+// ─ workspace persistence ─
+//
+// The editor content (files + active tab) survives a page refresh; the
+// simulator core state (registers, memory, PC, console) deliberately does
+// NOT — users expect a fresh run after reload, and persisting it would
+// bloat localStorage on every step. FileSystemFileHandle objects are not
+// serializable, so handles rehydrate as null (Save re-prompts, same as a
+// freshly opened tab).
+
+export const WORKSPACE_STORAGE_KEY = 'webmars:workspace-v1'
+
+export interface PersistedWorkspace {
+  files: Array<Pick<FileEntry, 'id' | 'name' | 'source' | 'modified'>>
+  activeFileId: string | null
+}
+
+export function readPersistedWorkspace(): PersistedWorkspace | null {
+  try {
+    const raw = typeof window === 'undefined' ? null : window.localStorage.getItem(WORKSPACE_STORAGE_KEY)
+    if (raw === null) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const obj = parsed as Record<string, unknown>
+    if (!Array.isArray(obj.files)) return null
+    const files: PersistedWorkspace['files'] = []
+    for (const entry of obj.files) {
+      if (typeof entry !== 'object' || entry === null) continue
+      const f = entry as Record<string, unknown>
+      if (typeof f.id === 'string' && typeof f.name === 'string' && typeof f.source === 'string') {
+        files.push({ id: f.id, name: f.name, source: f.source, modified: f.modified === true })
+      }
+    }
+    if (files.length === 0) return null
+    const activeFileId = typeof obj.activeFileId === 'string' ? obj.activeFileId : null
+    return { files, activeFileId }
+  } catch {
+    // Corrupt payload or privacy mode — fall back to the default file.
+    return null
+  }
+}
+
+export function writePersistedWorkspace(workspace: PersistedWorkspace): void {
+  try {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(WORKSPACE_STORAGE_KEY, JSON.stringify(workspace))
+  } catch {
+    // ignore — privacy mode / quota
+  }
+}
+
 // ─ bottom-panel messages ─
 
 export type BottomMessageLevel = 'info' | 'warn' | 'error'
@@ -966,20 +1016,31 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
   }
 
   // Hello MIPS becomes the initial file entry so screenshots show
-  // working code without anyone having to load it.
+  // working code without anyone having to load it. A persisted
+  // workspace from a previous session takes precedence — the loudest
+  // v1.1 complaint was losing code on refresh.
   const helloFileId = 'hello-mips'
-  const initialFiles: FileEntry[] = [
-    {
-      id: helloFileId,
-      name: 'hello.asm',
-      source: HELLO_MIPS_SOURCE,
-      handle: null,
-      modified: false,
-    },
-  ]
+  const persistedWorkspace = readPersistedWorkspace()
+  const initialFiles: FileEntry[] = persistedWorkspace
+    ? persistedWorkspace.files.map((f) => ({ ...f, handle: null }))
+    : [
+        {
+          id: helloFileId,
+          name: 'hello.asm',
+          source: HELLO_MIPS_SOURCE,
+          handle: null,
+          modified: false,
+        },
+      ]
+  const initialActiveFileId =
+    persistedWorkspace && initialFiles.some((f) => f.id === persistedWorkspace.activeFileId)
+      ? persistedWorkspace.activeFileId
+      : (initialFiles[0]?.id ?? helloFileId)
+  const initialSource =
+    initialFiles.find((f) => f.id === initialActiveFileId)?.source ?? HELLO_MIPS_SOURCE
 
   return {
-    source: HELLO_MIPS_SOURCE,
+    source: initialSource,
     status: 'idle',
     registers: initialRegisters,
     consoleOutput: [],
@@ -991,7 +1052,7 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
 
     // file slice
     files: initialFiles,
-    activeFileId: helloFileId,
+    activeFileId: initialActiveFileId,
     recentFiles: readRecentFiles(),
 
     // layout slice — initial values from localStorage (or viewport defaults)
@@ -1772,3 +1833,35 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
     },
   }
 })
+
+// ─ workspace persistence wiring ─
+//
+// A single store subscription persists the workspace whenever the file
+// slice changes. Writes are debounced so per-keystroke setSource calls
+// don't hammer localStorage; beforeunload flushes any pending write so
+// the very last keystrokes survive an immediate refresh.
+
+const WORKSPACE_WRITE_DEBOUNCE_MS = 250
+let _workspaceWriteTimer: ReturnType<typeof setTimeout> | null = null
+
+function flushWorkspaceWrite(): void {
+  if (_workspaceWriteTimer !== null) {
+    clearTimeout(_workspaceWriteTimer)
+    _workspaceWriteTimer = null
+  }
+  const s = useSimulator.getState()
+  writePersistedWorkspace({
+    files: s.files.map(({ id, name, source, modified }) => ({ id, name, source, modified })),
+    activeFileId: s.activeFileId,
+  })
+}
+
+useSimulator.subscribe((state, prev) => {
+  if (state.files === prev.files && state.activeFileId === prev.activeFileId) return
+  if (_workspaceWriteTimer !== null) clearTimeout(_workspaceWriteTimer)
+  _workspaceWriteTimer = setTimeout(flushWorkspaceWrite, WORKSPACE_WRITE_DEBOUNCE_MS)
+})
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeunload', flushWorkspaceWrite)
+}

--- a/src/tests/persist.test.ts
+++ b/src/tests/persist.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Workspace persistence (REQ-001): editor content survives a refresh,
+// simulator state does not. The store module reads localStorage at
+// import time, so each test stubs window + localStorage first and then
+// dynamically imports a FRESH copy of the store via vi.resetModules().
+
+function makeLocalStorageStub(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed))
+  return {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    _dump: () => Object.fromEntries(store),
+  }
+}
+
+type StoreModule = typeof import('../hooks/useSimulator')
+
+async function importFreshStore(seed: Record<string, string> = {}) {
+  const localStorage = makeLocalStorageStub(seed)
+  vi.stubGlobal('window', {
+    localStorage,
+    innerWidth: 1440,
+    innerHeight: 900,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    matchMedia: () => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  })
+  vi.resetModules()
+  const mod: StoreModule = await import('../hooks/useSimulator')
+  return { mod, localStorage }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('workspace persistence', () => {
+  it('writes the workspace key after the source changes (debounced)', async () => {
+    const { mod, localStorage } = await importFreshStore()
+    mod.useSimulator.getState().setSource('addi $t0, $zero, 999')
+    vi.advanceTimersByTime(300)
+
+    const raw = localStorage.getItem(mod.WORKSPACE_STORAGE_KEY)
+    expect(raw).not.toBeNull()
+    const payload = JSON.parse(raw!) as { files: Array<{ source: string }> }
+    expect(payload.files.some((f) => f.source === 'addi $t0, $zero, 999')).toBe(true)
+  })
+
+  it('rehydrates source and active file from a persisted workspace', async () => {
+    const seeded = {
+      'webmars:workspace-v1': JSON.stringify({
+        files: [
+          { id: 'a', name: 'a.asm', source: 'li $t0, 1', modified: false },
+          { id: 'b', name: 'b.asm', source: 'li $t1, 2', modified: true },
+        ],
+        activeFileId: 'b',
+      }),
+    }
+    const { mod } = await importFreshStore(seeded)
+    const s = mod.useSimulator.getState()
+    expect(s.source).toBe('li $t1, 2')
+    expect(s.activeFileId).toBe('b')
+    expect(s.files).toHaveLength(2)
+    // Handles are not serializable; they rehydrate as null.
+    expect(s.files.every((f) => f.handle === null)).toBe(true)
+  })
+
+  it('never persists simulator state (registers, memory, console)', async () => {
+    const { mod, localStorage } = await importFreshStore()
+    mod.useSimulator.getState().setSource('li $v0, 10\nsyscall\n')
+    vi.advanceTimersByTime(300)
+
+    const raw = localStorage.getItem(mod.WORKSPACE_STORAGE_KEY)!
+    const payload = JSON.parse(raw) as Record<string, unknown>
+    expect(Object.keys(payload).sort()).toEqual(['activeFileId', 'files'])
+    expect(raw).not.toContain('registers')
+    expect(raw).not.toContain('consoleOutput')
+    expect(raw).not.toContain('programCounter')
+  })
+
+  it('falls back to the default file when the payload is corrupt', async () => {
+    const { mod } = await importFreshStore({ 'webmars:workspace-v1': '{not json' })
+    const s = mod.useSimulator.getState()
+    expect(s.files).toHaveLength(1)
+    expect(s.files[0]?.name).toBe('hello.asm')
+    expect(s.source).toContain('Welcome to WebMARS')
+  })
+})


### PR DESCRIPTION
## Agent
AGENT 03 - Editor Persistence Across Refresh (loop position: 4 of 18)

## Requirements delivered
- REQ-001 - workspace (files + active tab) survives refresh; simulator state does not - src/hooks/useSimulator.ts

## What changed and why
Fixes the loudest v1.1 complaint (Enhancement Plan section 2.1): refreshing lost all editor work. The workspace persists to webmars:workspace-v1 via a store subscription (debounced 250ms, beforeunload flush) and hydrates on boot. Followed the store's existing manual per-key persistence convention rather than the plan's persist-middleware sketch - same behavior, consistent codebase. Simulator state is excluded by construction; a test asserts the payload contains exactly [activeFileId, files].

## Evidence summary
- Build: npm run build -> exit 0; typecheck + lint -> exit 0
- Tests: npm test -> 134/134 (4 new in src/tests/persist.test.ts)

## Out of scope / follow-ups
snippet metadata joins the persisted payload when AGENT 08 adds it. Live-browser refresh walkthrough lands with AGENT 91 Q1.