### PR TITLE
agent-04: Monaco light theme + system theme preference

### DIFF
--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -160,7 +160,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   ── DYNAMIC IMPLEMENTATION AGENTS (inserted by AGENT 01) ──────────────────────
   AGENT 02 — API Client, Toast System & Env-Aware Base URL ...... ✅ COMPLETE
   AGENT 03 — Editor Persistence Across Refresh .................. ✅ COMPLETE
-  AGENT 04 — Monaco Light Theme + System Preference ............. ⬜ NOT STARTED
+  AGENT 04 — Monaco Light Theme + System Preference ............. ✅ COMPLETE
   AGENT 05 — rem Pseudo-Instruction (Assembler + Tests) ......... ⬜ NOT STARTED
   AGENT 06 — Tools: Bitmap Grid Sizes + Screen Magnifier ........ ⬜ NOT STARTED
   AGENT 07 — Accounts UI: Auth Slice + AuthModal + Toolbar ...... ⬜ NOT STARTED
@@ -221,7 +221,13 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   (files + active tab) persists to webmars:workspace-v1, debounced 250ms
   with beforeunload flush; hydrates on boot; simulator state provably
   excluded (payload keys asserted in test). 4 new tests; 134/134 green;
-  typecheck/lint/build exit 0. PR #43.
+  typecheck/lint/build exit 0. PR #43 merged, main @ e8c6a68.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 04: Monaco light theme + system preference (REQ-002)
+  done. webmars-light registered; theme prop derived via resolveTheme;
+  'system' option follows matchMedia live; SettingsDialog copy fixed.
+  LIVE browser proof: editor bg rgb(10,10,10)→rgb(255,255,255)→back on
+  radio toggles (playwright + Edge headless). 134/134 green. PR #44.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -781,7 +787,29 @@ APPENDIX A-03 — Editor Persistence
   PR # / MAIN COMMIT: PR #43.
 --------------------------------------------------------------------------------
 APPENDIX A-04 — Monaco Light Theme + System Preference
-  STATUS: / DATE: / PER-REQ (002): / BUILD+TEST: / PR #:
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  REQ-002: IMPLEMENTED —
+    src/lib/mipsLanguage.ts: webmars-light theme defined beside
+      webmars-dark (hex mirrors tokens.css [data-theme="light"]); both
+      registered in registerMips.
+    src/hooks/useSimulator.ts: ThemeName gains 'system'; THEMES + persisted
+      validation accept it; resolveTheme(pref, systemScheme) exported.
+    src/hooks/useSystemColorScheme.ts: NEW matchMedia hook with live
+      change listener.
+    src/ui/CodeEditor.tsx: theme prop derived (light → webmars-light;
+      hc → webmars-dark per A-01 interpretation).
+    src/ui/Shell.tsx: data-theme = resolveTheme(...), re-applies live on
+      OS flips. src/App.tsx: Toaster follows resolved theme.
+    src/ui/SettingsDialog.tsx: System radio option added; stale copy
+      ("Editor stays on the dark Monaco theme") corrected.
+  LIVE BROWSER VERIFICATION (playwright-core + Edge headless against
+    npm run dev): Monaco .monaco-editor-background computed color
+    rgb(10,10,10) in dark → rgb(255,255,255) after checking Light in
+    SettingsDialog → rgb(10,10,10) after checking Dark again; data-theme
+    ="light" applied; System resolved to host scheme. Screenshots
+    captured (dark + light) — light shell renders with all 4 options.
+  BUILD+TEST: typecheck 0 / lint 0 / build exit 0 / vitest 134/134.
+  PR # / MAIN COMMIT: PR #44.
 --------------------------------------------------------------------------------
 APPENDIX A-05 — rem Pseudo-Instruction
   STATUS: / DATE: / PER-REQ (023): / BUILD+TEST: / PR #:
@@ -824,7 +852,7 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   ID      | PDF PAGE/SECTION | SUMMARY | CATEGORY | OWNER | STATUS | PR # | EVIDENCE
   --------|------------------|---------|----------|-------|--------|------|---------
   REQ-001 | p.5-6 §2.1; p.32 §6.2 | Persist editor source/files/activeFileId across refresh; simulator state NOT persisted; private-mode safe; last-write-wins OK [mechanism per codebase convention, SF5] | FIX | A03 | IMPLEMENTED | #43 | useSimulator.ts workspace helpers + subscribe; persist.test.ts (4 tests)
-  REQ-002 | p.6-7 §2.2; p.33-34 §6.3 | Monaco webmars-light theme; theme preference incl. 'system' w/ live OS tracking; SettingsDialog picker; shell+editor stay in sync [hc keeps dark Monaco] | FIX | A04 | ⬜ | |
+  REQ-002 | p.6-7 §2.2; p.33-34 §6.3 | Monaco webmars-light theme; theme preference incl. 'system' w/ live OS tracking; SettingsDialog picker; shell+editor stay in sync [hc keeps dark Monaco] | FIX | A04 | IMPLEMENTED | #44 | mipsLanguage.ts webmars-light; browser-verified bg #0a0a0a→#ffffff; A-04
   REQ-003 | p.7-8 §2.3 | Backend: DELETE /snippets/{id} owner check, 404 to non-owners | SECURITY | A12 | ⬜ | | pre-exists upstream (verify)
   REQ-004 | p.8 §2.4 | Backend: login failures return 401 'Invalid credentials' (same msg both cases) | FIX | A12 | ⬜ | | pre-exists upstream (verify)
   REQ-005 | p.8-9 §2.5; p.38 §7.1; p.56 §10.1 | Backend secrets: env-var indirection, .env.example, .gitignore, rotation, git-history scrub + force-push + re-clone | SECURITY | A12 | ⬜ | | partial upstream; rotation/scrub = owner

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,8 @@ import { Suspense, lazy } from 'react'
 import { Toaster } from 'sonner'
 import { useRoute } from '@/lib/router.ts'
 import { Shell } from '@/ui/Shell.tsx'
-import { useSimulator } from '@/hooks/useSimulator.ts'
+import { useSimulator, resolveTheme } from '@/hooks/useSimulator.ts'
+import { useSystemColorScheme } from '@/hooks/useSystemColorScheme.ts'
 
 // Lazy-load the landing page so the IDE bundle isn't burdened with
 // marketing CSS for the default route. Users who deep-link to / get the
@@ -13,10 +14,11 @@ const LandingPage = lazy(() => import('@/landing/LandingPage.tsx'))
 export default function App() {
   const route = useRoute()
   const theme = useSimulator((s) => s.theme)
+  const systemScheme = useSystemColorScheme()
 
   // Sonner only knows light/dark; the high-contrast shell keeps the
   // dark toast styling.
-  const toasterTheme = theme === 'light' ? 'light' : 'dark'
+  const toasterTheme = resolveTheme(theme, systemScheme) === 'light' ? 'light' : 'dark'
 
   if (route === 'landing') {
     return (

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -405,9 +405,17 @@ function writePersistedMemoryView(view: PersistedMemoryView): void {
 
 // ─ settings (theme / font / simulator toggles) ─
 
-export type ThemeName = 'dark' | 'light' | 'hc'
+// 'system' follows the OS light/dark preference live (via the
+// useSystemColorScheme hook). resolveTheme collapses the preference
+// to a concrete shell theme; 'hc' is its own concrete theme.
+export type ThemeName = 'dark' | 'light' | 'hc' | 'system'
+export type ResolvedTheme = 'dark' | 'light' | 'hc'
 
-export const THEMES: ReadonlyArray<ThemeName> = ['dark', 'light', 'hc']
+export const THEMES: ReadonlyArray<ThemeName> = ['dark', 'light', 'hc', 'system']
+
+export function resolveTheme(preference: ThemeName, systemScheme: 'light' | 'dark'): ResolvedTheme {
+  return preference === 'system' ? systemScheme : preference
+}
 
 export const EDITOR_FONT_MIN  = 10
 export const EDITOR_FONT_MAX  = 22

--- a/src/hooks/useSystemColorScheme.ts
+++ b/src/hooks/useSystemColorScheme.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+
+// Tracks the OS-level color-scheme preference, live. Used by the
+// 'system' theme option so the shell and Monaco follow the OS without
+// a reload.
+
+export type SystemColorScheme = 'light' | 'dark'
+
+function readSystemScheme(): SystemColorScheme {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return 'dark'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function useSystemColorScheme(): SystemColorScheme {
+  const [scheme, setScheme] = useState<SystemColorScheme>(readSystemScheme)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = () => setScheme(mq.matches ? 'dark' : 'light')
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  return scheme
+}

--- a/src/lib/mipsLanguage.ts
+++ b/src/lib/mipsLanguage.ts
@@ -226,7 +226,7 @@ const monarchTokens: languages.IMonarchLanguage = {
   },
 }
 
-const themeData = {
+const darkThemeData = {
   base: 'vs-dark' as const,
   inherit: true,
   rules: [
@@ -275,6 +275,56 @@ const themeData = {
   },
 }
 
+// Light sibling of webmars-dark. The hex literals mirror the
+// [data-theme="light"] block in src/ui/tokens.css so the editor and
+// shell shift together when the theme preference is light (or system
+// resolves light).
+const lightThemeData = {
+  base: 'vs' as const,
+  inherit: true,
+  rules: [
+    { token: 'comment',       foreground: 'a1a1aa', fontStyle: 'italic' },   // --ink-3
+    { token: 'keyword',       foreground: '0891b2' },                        // --accent
+    { token: 'number',        foreground: '18181b' },                        // --ink-1
+    { token: 'number.hex',    foreground: '18181b' },
+    { token: 'string',        foreground: '059669' },                        // --ok
+    { token: 'string.escape', foreground: 'd97706' },                        // --warn
+    { token: 'string.quote',  foreground: '059669' },
+    { token: 'directive',     foreground: 'd97706' },                        // --warn
+    { token: 'register',      foreground: '0891b2', fontStyle: 'bold' },     // --accent bold
+    { token: 'label',         foreground: '18181b', fontStyle: 'bold' },     // --ink-1 bold
+    { token: 'identifier',    foreground: '52525b' },                        // --ink-2
+    { token: 'delimiter',     foreground: '52525b' },
+    { token: 'invalid',       foreground: 'dc2626' },                        // --danger
+  ],
+  colors: {
+    'editor.background':                  '#ffffff', // --surface-1
+    'editor.foreground':                  '#18181b', // --ink-1
+    'editorLineNumber.foreground':        '#a1a1aa', // --ink-3
+    'editorLineNumber.activeForeground':  '#18181b',
+    'editor.lineHighlightBackground':     '#f4f4f580', // --surface-2 with 50% alpha
+    'editor.lineHighlightBorder':         '#f4f4f500',
+    'editorCursor.foreground':            '#0891b2', // --accent
+    'editor.selectionBackground':         '#0891b233',
+    'editor.inactiveSelectionBackground': '#0891b21a',
+    'editorIndentGuide.background':       '#e4e4e7', // --column-guide
+    'editorIndentGuide.activeBackground': '#d4d4d8', // --border
+    'editorRuler.foreground':             '#e4e4e7',
+    'editorWidget.background':            '#ffffff', // --surface-elev
+    'editorWidget.border':                '#d4d4d8', // --border
+    'editorHoverWidget.background':       '#ffffff',
+    'editorHoverWidget.border':           '#d4d4d8',
+    'editorBracketMatch.background':      '#0891b222',
+    'editorBracketMatch.border':          '#0891b2',
+    'editorError.foreground':             '#dc2626',
+    'editorWarning.foreground':           '#d97706',
+    'scrollbar.shadow':                   '#00000000',
+    'scrollbarSlider.background':         '#e4e4e780',
+    'scrollbarSlider.hoverBackground':    '#a1a1aa',
+    'scrollbarSlider.activeBackground':   '#a1a1aa',
+  },
+}
+
 const hoverProvider: languages.HoverProvider = {
   provideHover(model, position) {
     const word = model.getWordAtPosition(position)
@@ -307,7 +357,8 @@ export function registerMips(monaco: Monaco): void {
   monaco.languages.register({ id: 'mips', extensions: ['.asm', '.s', '.S', '.mips'], aliases: ['MIPS', 'mips'] })
   monaco.languages.setMonarchTokensProvider('mips', monarchTokens)
   monaco.languages.registerHoverProvider('mips', hoverProvider)
-  monaco.editor.defineTheme('webmars-dark', themeData)
+  monaco.editor.defineTheme('webmars-dark', darkThemeData)
+  monaco.editor.defineTheme('webmars-light', lightThemeData)
 }
 
 export { INSTRUCTION_REFERENCE, MNEMONICS }

--- a/src/ui/CodeEditor.tsx
+++ b/src/ui/CodeEditor.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { Editor, type Monaco, type OnMount } from '@monaco-editor/react'
 import type { editor as monacoEditor } from 'monaco-editor'
-import { useSimulator } from '@/hooks/useSimulator.ts'
+import { useSimulator, resolveTheme } from '@/hooks/useSimulator.ts'
 import { useIsMobile } from '@/hooks/useIsMobile.ts'
+import { useSystemColorScheme } from '@/hooks/useSystemColorScheme.ts'
 import { registerMips } from '@/lib/mipsLanguage.ts'
 import { JUMP_TO_LINE_EVENT, type JumpToLineDetail } from '@/lib/jumpToLine.ts'
 import { setEditorCursorReader } from '@/lib/editorCursor.ts'
@@ -28,7 +29,15 @@ export function CodeEditor() {
   const breakpoints      = useSimulator((s) => s.breakpoints)
   const editorFontSize   = useSimulator((s) => s.editorFontSize)
   const mobileEditAllowed= useSimulator((s) => s.mobileEditAllowed)
+  const theme            = useSimulator((s) => s.theme)
+  const systemScheme     = useSystemColorScheme()
   const isMobile         = useIsMobile()
+
+  // The editor follows the app theme (Enhancement Plan §2.2). 'hc'
+  // keeps the dark Monaco theme — its AAA treatment applies to shell
+  // chrome; a dedicated hc Monaco theme is not part of v1.2.
+  const editorTheme =
+    resolveTheme(theme, systemScheme) === 'light' ? 'webmars-light' : 'webmars-dark'
 
   const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null)
   const monacoRef = useRef<Monaco | null>(null)
@@ -217,7 +226,7 @@ export function CodeEditor() {
         height={size.h || '100%'}
         width={size.w || '100%'}
       language="mips"
-      theme="webmars-dark"
+      theme={editorTheme}
       value={source}
       onChange={(value) => setSource(value ?? '')}
       beforeMount={handleBeforeMount}

--- a/src/ui/SettingsDialog.tsx
+++ b/src/ui/SettingsDialog.tsx
@@ -18,9 +18,10 @@ const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
 ]
 
 const THEME_LABELS: Record<ThemeName, { title: string; sub: string }> = {
-  dark:  { title: 'Dark',           sub: 'Default. Low-contrast surfaces, cyan accent.' },
-  light: { title: 'Light',          sub: 'Inverted shell. Editor stays on the dark Monaco theme.' },
-  hc:    { title: 'High contrast',  sub: 'Pure-black + max ink. WCAG AAA on shell chrome.' },
+  dark:   { title: 'Dark',           sub: 'Default. Low-contrast surfaces, cyan accent.' },
+  light:  { title: 'Light',          sub: 'Inverted shell and a matching light editor theme.' },
+  hc:     { title: 'High contrast',  sub: 'Pure-black + max ink. WCAG AAA on shell chrome.' },
+  system: { title: 'System',         sub: 'Follows your OS light/dark preference, live.' },
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -205,9 +206,9 @@ export function SettingsDialog() {
                   ))}
                 </div>
                 <p className="text-[10px] italic text-ink-3">
-                  Monaco's editor theme is dark in every mode — light /
-                  HC swap shell chrome only. A matching editor theme
-                  lands when the language registration is refactored.
+                  Light and System themes switch the Monaco editor too.
+                  High contrast keeps the dark editor theme — its AAA
+                  treatment applies to shell chrome.
                 </p>
               </Section>
             )}

--- a/src/ui/Shell.tsx
+++ b/src/ui/Shell.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
-import { useSimulator } from '@/hooks/useSimulator.ts'
+import { useSimulator, resolveTheme } from '@/hooks/useSimulator.ts'
 import { useIsMobile } from '@/hooks/useIsMobile.ts'
+import { useSystemColorScheme } from '@/hooks/useSystemColorScheme.ts'
 import { MenuBar } from './MenuBar.tsx'
 import { Toolbar } from './Toolbar.tsx'
 import { TabStrip } from './TabStrip.tsx'
@@ -38,13 +39,16 @@ export function Shell() {
   const layoutSizes      = useSimulator((s) => s.layoutSizes)
   const setLayoutSize    = useSimulator((s) => s.setLayoutSize)
   const isMobile         = useIsMobile()
+  const systemScheme     = useSystemColorScheme()
 
   // Apply theme via documentElement.dataset.theme. tokens.css scopes
   // light + HC overrides under [data-theme="…"] selectors so every
   // var(--…) reader picks up the new value without code changes.
+  // 'system' resolves to light/dark from the OS preference and
+  // re-applies live when the OS theme flips.
   useEffect(() => {
-    document.documentElement.dataset.theme = theme
-  }, [theme])
+    document.documentElement.dataset.theme = resolveTheme(theme, systemScheme)
+  }, [theme, systemScheme])
 
   // Install the global keybinding map (Ctrl+S, F5, F7, etc.). The
   // module reads the store via getState() so the listener doesn't


### PR DESCRIPTION
## Agent
AGENT 04 - Monaco Light Theme + System Preference (loop position: 5 of 18)

## Requirements delivered
- REQ-002 - webmars-light Monaco theme, 'system' theme option with live OS tracking, editor follows app theme

## What changed and why
Fixes Enhancement Plan section 2.2 (light mode showed a dark editor). webmars-light is defined beside webmars-dark with hex mirroring tokens.css light tokens; CodeEditor derives its theme via resolveTheme(preference, systemScheme); a new useSystemColorScheme hook tracks matchMedia live; SettingsDialog gains a System option and its stale editor-stays-dark copy is corrected. High contrast intentionally keeps the dark editor (AAA treatment is shell chrome scope - noted in the matrix interpretation).

## Evidence summary
- Live browser proof (playwright + Edge headless): editor background rgb(10,10,10) -> rgb(255,255,255) -> back, via the settings radios; data-theme applied; System resolves from OS
- Build/typecheck/lint exit 0; tests 134/134