### PR TITLE
agent-05: add rem pseudo-instruction with tests and docs

### DIFF
--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -161,7 +161,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   AGENT 02 — API Client, Toast System & Env-Aware Base URL ...... ✅ COMPLETE
   AGENT 03 — Editor Persistence Across Refresh .................. ✅ COMPLETE
   AGENT 04 — Monaco Light Theme + System Preference ............. ✅ COMPLETE
-  AGENT 05 — rem Pseudo-Instruction (Assembler + Tests) ......... ⬜ NOT STARTED
+  AGENT 05 — rem Pseudo-Instruction (Assembler + Tests) ......... ✅ COMPLETE
   AGENT 06 — Tools: Bitmap Grid Sizes + Screen Magnifier ........ ⬜ NOT STARTED
   AGENT 07 — Accounts UI: Auth Slice + AuthModal + Toolbar ...... ⬜ NOT STARTED
   AGENT 08 — Save, Share & Deep Links (?snippet=<id>) ........... ⬜ NOT STARTED
@@ -227,7 +227,15 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   done. webmars-light registered; theme prop derived via resolveTheme;
   'system' option follows matchMedia live; SettingsDialog copy fixed.
   LIVE browser proof: editor bg rgb(10,10,10)→rgb(255,255,255)→back on
-  radio toggles (playwright + Edge headless). 134/134 green. PR #44.
+  radio toggles (playwright + Edge headless). 134/134 green. PR #44
+  merged, main @ e7ea3c4.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 05: rem pseudo-instruction (REQ-023) done. Ground-
+  truth correction: live assembler is src/core/instructions.ts, not the
+  dormant src/core/assembler/ files the PDF names — implemented in both.
+  div+mfhi expansion, pass-1 sizing, syntax highlight, hover ref, help
+  entry. 4 new tests incl. negative dividend + rem-by-zero. 138/138
+  green. PR #45.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -812,7 +820,28 @@ APPENDIX A-04 — Monaco Light Theme + System Preference
   PR # / MAIN COMMIT: PR #44.
 --------------------------------------------------------------------------------
 APPENDIX A-05 — rem Pseudo-Instruction
-  STATUS: / DATE: / PER-REQ (023): / BUILD+TEST: / PR #:
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  REQ-023: IMPLEMENTED — IMPORTANT GROUND-TRUTH CORRECTION: the app's LIVE
+    assembler is src/core/instructions.ts (single-file lexer+parser+
+    emitter); src/core/assembler/{lexer,parser,assembler}.ts (the files
+    the PDF names) is a dormant parallel implementation not imported by
+    the app. rem implemented in BOTH:
+    - src/core/instructions.ts: pass-1 size entry (rem → +8 bytes) +
+      second-pass case 'rem' → div $rs,$rt (funct 0x1a) + mfhi $rd
+      (funct 0x10), sourceMap kept in sync.
+    - src/core/assembler/*: mnemonic, ["R","R","R"] signature, expansion
+      case (parity with the PDF's named files).
+    - src/lib/mipsLanguage.ts: rem added to highlight MNEMONICS + hover
+      INSTRUCTION_REFERENCE. src/lib/instructionReference.ts: rem row in
+      the pseudo category → renders automatically in HelpDialog's
+      Pseudo-Instructions tab (REQ-042 contribution).
+    Tests (src/tests/pseudoInstructions.test.ts — repo's pseudo-op home,
+    not a new assembler.test.ts; codebase convention): expansion adds
+    exactly one extra word vs nop; 17 rem 5 prints '2'; -17 rem 5 prints
+    '-2' (dividend-sign semantics); rem-by-zero rejects with the
+    runtime's existing 'Division by zero'.
+  BUILD+TEST: typecheck 0 / lint 0 / build exit 0 / vitest 138/138.
+  PR # / MAIN COMMIT: PR #45.
 --------------------------------------------------------------------------------
 APPENDIX A-06 — Tools: Bitmap + Magnifier
   STATUS: / DATE: / PER-REQ (006/028/029): / BUILD+TEST: / PR #:
@@ -873,7 +902,7 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-020 | p.30-32 §6.1 | src/lib/api.ts typed client: ApiError, authHeader, request<T> w/ 204, full auth/snippets/runs surface per skeleton | FEATURE | A02 | IMPLEMENTED | #42 | src/lib/api.ts; src/tests/api.test.ts (5 tests)
   REQ-021 | p.34-35 §6.4; p.22 D4 | Auth slice (webmars.token/webmars.username) + AuthModal (tabs, busy, 401/409/429/network msg map) + toolbar Sign-in/username/Log-out | FEATURE | A07 | ⬜ | |
   REQ-022 | p.36 §6.5; p.23 D5 | Save-to-Account + ShareModal: create-vs-update semantics, copy link + toast, visibility shown + toggle → PUT | FEATURE | A08 | ⬜ | |
-  REQ-023 | p.44-45 §7.7; p.22-24 D4-D5 | rem pseudo-instruction: lexer mnemonic, parser ["R","R","R"], assembler div+mfhi expansion | FEATURE | A05 | ⬜ | |
+  REQ-023 | p.44-45 §7.7; p.22-24 D4-D5 | rem pseudo-instruction: lexer mnemonic, parser ["R","R","R"], assembler div+mfhi expansion [live assembler is instructions.ts; PDF-named files also updated] | FEATURE | A05 | IMPLEMENTED | #45 | instructions.ts rem case; pseudoInstructions.test.ts +4 tests
   REQ-024 | p.40 §7.3; p.24 D5 | Snippet entity v1.2: owner FK lazy, Visibility enum STRING, created/updated timestamps + lifecycle hooks | FEATURE | A12 | ⬜ | | pre-exists (verify)
   REQ-025 | p.40-42 §7.4; p.24 D6 | Run entity + RunRepository: findByUserIdOrderByStartedAtDesc + most-run JPQL projection | FEATURE | A12 | ⬜ | | pre-exists (verify)
   REQ-026 | p.42-43 §7.5; p.24 D6 | SnippetController v1.2: visibility-gated GET, /mine, /public paginated (size cap 100), /save sets owner, PUT update, DELETE owner-checked | FEATURE | A12 | ⬜ | | PUT missing upstream → fork PR

--- a/src/core/assembler/assembler.ts
+++ b/src/core/assembler/assembler.ts
@@ -372,6 +372,14 @@ function translateIR(
       "0000000000000000" + reg(op0) + "00000010010",         // mflo rd
     ];
 
+    // ── Pseudo: rem rd, rs, rt  →  div rs, rt  +  mfhi rd ───────────────────
+    // The remainder lands in HI after a div; rem-by-zero behaves exactly
+    // like div-by-zero (passes through to the runtime's existing rule).
+    case "rem": return [
+      "000000" + reg(op1) + reg(op2) + "0000000000011010",  // div rs, rt
+      "0000000000000000" + reg(op0) + "00000010000",         // mfhi rd
+    ];
+
     // ── J-type ───────────────────────────────────────────────────────────────
     case "j":   return ["000010" + jumpTarget(op0, labelMap)];
     case "jal": return ["000011" + jumpTarget(op0, labelMap)];

--- a/src/core/assembler/lexer.ts
+++ b/src/core/assembler/lexer.ts
@@ -60,7 +60,7 @@ const MNEMONICS = new Set([
   // Pseudo
   "li", "la", "move", "nop", "syscall", "break",
   "blt", "ble", "bgt", "bge",
-  "mul", "neg", "not",
+  "mul", "rem", "neg", "not",
   "push", "pop",
 ]);
 

--- a/src/core/assembler/parser.ts
+++ b/src/core/assembler/parser.ts
@@ -110,6 +110,7 @@ const INSTRUCTION_SCHEMA: Record<string, OperandKind[]> = {
   la:    ["R","L"],
   move:  ["R","R"],
   mul:   ["R","R","R"],
+  rem:   ["R","R","R"],
   neg:   ["R","R"], not: ["R","R"],
   // No operands
   nop:      [],

--- a/src/core/instructions.ts
+++ b/src/core/instructions.ts
@@ -238,6 +238,8 @@ export function assemble(source: string): AssembledProgram {
           textAddr += 8; // slt + (beq|bne)
         } else if (mn === 'sge') {
           textAddr += 8; // slt + xori
+        } else if (mn === 'rem') {
+          textAddr += 8; // div + mfhi
         } else if (mn === 'abs') {
           textAddr += 12; // sra + xor + sub
         } else {
@@ -694,6 +696,16 @@ export function assemble(source: string): AssembledProgram {
             // sgt $rd, $rs, $rt → slt $rd, $rt, $rs (operands swapped)
             const rd2 = getR(0); const rs2 = getR(2); const rt2 = getR(4);
             instr = rType(0, rt2, rs2, rd2, 0, 0x2a);
+            consumed = 5; break;
+          }
+          case 'rem': {
+            // rem $rd, $rs, $rt → div $rs, $rt; mfhi $rd
+            // (Enhancement Plan §7.7 — the remainder lands in HI.
+            // rem-by-zero hits the runtime's existing div-by-zero rule.)
+            const rd2 = getR(0); const rs2 = getR(2); const rt2 = getR(4);
+            instructions.push(rType(0, rs2, rt2, 0, 0, 0x1a));  // div $rs, $rt
+            textAddr += 4; sourceMap.set(textAddr, line);
+            instr = rType(0, 0, 0, rd2, 0, 0x10);               // mfhi $rd
             consumed = 5; break;
           }
           case 'neg': {

--- a/src/lib/instructionReference.ts
+++ b/src/lib/instructionReference.ts
@@ -135,6 +135,7 @@ export const INSTRUCTION_ENTRIES: ReadonlyArray<InstructionEntry> = [
   { mnemonic: 'abs',  category: 'pseudo', format: 'abs $rd, $rs',          description: 'Absolute value. sra + xor + sub.' },
   { mnemonic: 'sge',  category: 'pseudo', format: 'sge $rd, $rs, $rt',     description: 'Set if greater or equal. slt + xori 1.' },
   { mnemonic: 'sgt',  category: 'pseudo', format: 'sgt $rd, $rs, $rt',     description: 'Set if greater than. slt with operands swapped.' },
+  { mnemonic: 'rem',  category: 'pseudo', format: 'rem $rd, $rs, $rt',     description: 'Remainder. div $rs, $rt + mfhi $rd. Remainder by zero raises the same runtime error as div by zero.' },
   { mnemonic: 'neg',  category: 'pseudo', format: 'neg $rd, $rs',          description: 'Negate. sub $rd, $zero, $rs.' },
   { mnemonic: 'not',  category: 'pseudo', format: 'not $rd, $rs',          description: 'Bitwise NOT. nor $rd, $rs, $zero.' },
   { mnemonic: 'nop',  category: 'pseudo', format: 'nop',                   description: 'No operation. sll $zero, $zero, 0.' },

--- a/src/lib/mipsLanguage.ts
+++ b/src/lib/mipsLanguage.ts
@@ -17,7 +17,7 @@ const MNEMONICS = [
   'add', 'addu', 'sub', 'subu', 'and', 'or', 'xor', 'nor',
   'sll', 'srl', 'sra', 'sllv', 'srlv', 'srav',
   'slt', 'sltu',
-  'mult', 'multu', 'div', 'divu', 'mul',
+  'mult', 'multu', 'div', 'divu', 'mul', 'rem',
   'mfhi', 'mflo', 'mthi', 'mtlo',
   // I-type arithmetic / logical
   'addi', 'addiu', 'andi', 'ori', 'xori', 'slti', 'sltiu', 'lui',
@@ -77,6 +77,7 @@ const INSTRUCTION_REFERENCE: Record<string, InstructionRef> = {
   multu:  { signature: 'multu $rs, $rt',         desc: 'Multiply unsigned. HI:LO = $rs * $rt.' },
   div:    { signature: 'div $rs, $rt',           desc: 'Divide signed. LO = $rs / $rt; HI = $rs % $rt.' },
   divu:   { signature: 'divu $rs, $rt',          desc: 'Divide unsigned. LO = quotient; HI = remainder.' },
+  rem:    { signature: 'rem $rd, $rs, $rt',      desc: 'Remainder (pseudo). Expands to div $rs, $rt + mfhi $rd.' },
   mfhi:   { signature: 'mfhi $rd',               desc: 'Move from HI. $rd = HI.' },
   mflo:   { signature: 'mflo $rd',               desc: 'Move from LO. $rd = LO.' },
 

--- a/src/tests/pseudoInstructions.test.ts
+++ b/src/tests/pseudoInstructions.test.ts
@@ -271,4 +271,70 @@ describe('Pseudo-instructions (Phase 3 SA-2)', () => {
     `)
     expect(out).toBe('7')
   })
+
+  // ── rem (Enhancement Plan §7.7) — div $rs, $rt + mfhi $rd ──────────
+
+  it('rem expands to two machine words', () => {
+    const withRem = assemble(`
+      .text
+      main:
+        rem     $t0, $t1, $t2
+    `)
+    expect(withRem.errors).toEqual([])
+    const withoutRem = assemble(`
+      .text
+      main:
+        nop
+    `)
+    expect(withoutRem.errors).toEqual([])
+    expect(withRem.instructions.length).toBe(withoutRem.instructions.length + 1)
+  })
+
+  it('rem computes a positive remainder', async () => {
+    const out = await runAndPrintV0(`
+      .text
+      main:
+        li      $t1, 17
+        li      $t2, 5
+        rem     $t0, $t1, $t2
+        move    $a0, $t0
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(out).toBe('2')
+  })
+
+  it('rem of a negative dividend keeps the dividend sign (MIPS div semantics)', async () => {
+    const out = await runAndPrintV0(`
+      .text
+      main:
+        li      $t1, -17
+        li      $t2, 5
+        rem     $t0, $t1, $t2
+        move    $a0, $t0
+        li      $v0, 1
+        syscall
+        li      $v0, 10
+        syscall
+    `)
+    expect(out).toBe('-2')
+  })
+
+  it('rem by zero raises the same runtime error as div by zero', async () => {
+    const program = assemble(`
+      .text
+      main:
+        li      $t1, 17
+        li      $t2, 0
+        rem     $t0, $t1, $t2
+        li      $v0, 10
+        syscall
+    `)
+    expect(program.errors).toEqual([])
+    const sim = new Simulator(makeIO([]))
+    sim.load(program)
+    await expect(sim.run()).rejects.toThrow(/division by zero/i)
+  })
 })


### PR DESCRIPTION
## Agent
AGENT 05 - rem Pseudo-Instruction (loop position: 6 of 18)

## Requirements delivered
- REQ-023 - rem \, \, \ expanding to div + mfhi, with tests and help docs

## What changed and why
Implements Enhancement Plan section 7.7. Ground-truth correction: the app's live assembler is src/core/instructions.ts, not src/core/assembler/ as the plan assumed - rem is implemented in both (live path: pass-1 size entry + second-pass expansion with sourceMap sync). Also added to syntax-highlight mnemonics, hover reference, and the instruction reference that feeds the Help dialog's Pseudo-Instructions tab.

## Evidence summary
- Tests: 138/138; new: two-word expansion, 17 rem 5 = 2, -17 rem 5 = -2, rem-by-zero raises 'Division by zero'
- Build/typecheck/lint exit 0