### PR TITLE
agent-06: bitmap 8x8/16x16 grids + working DOM-clone screen magnifier

### DIFF
--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -162,7 +162,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   AGENT 03 — Editor Persistence Across Refresh .................. ✅ COMPLETE
   AGENT 04 — Monaco Light Theme + System Preference ............. ✅ COMPLETE
   AGENT 05 — rem Pseudo-Instruction (Assembler + Tests) ......... ✅ COMPLETE
-  AGENT 06 — Tools: Bitmap Grid Sizes + Screen Magnifier ........ ⬜ NOT STARTED
+  AGENT 06 — Tools: Bitmap Grid Sizes + Screen Magnifier ........ ✅ COMPLETE
   AGENT 07 — Accounts UI: Auth Slice + AuthModal + Toolbar ...... ⬜ NOT STARTED
   AGENT 08 — Save, Share & Deep Links (?snippet=<id>) ........... ⬜ NOT STARTED
   AGENT 09 — My Snippets Drawer + Public Feed ................... ⬜ NOT STARTED
@@ -235,7 +235,13 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   dormant src/core/assembler/ files the PDF names — implemented in both.
   div+mfhi expansion, pass-1 sizing, syntax highlight, hover ref, help
   entry. 4 new tests incl. negative dividend + rem-by-zero. 138/138
-  green. PR #45.
+  green. PR #45 merged, main @ 9af22c9.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 06: tools (REQ-006/028/029) done. Bitmap 8×8+16×16
+  options; 8 panels tagged data-magnify-region; ScreenMagnifier rewritten
+  as DOM-clone loupe (re-clone only on target change). Live browser
+  proof: options list, clone-present on register table hover, hint on
+  Monaco hover, Escape closes. 138/138 green. PR #46.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -844,7 +850,32 @@ APPENDIX A-05 — rem Pseudo-Instruction
   PR # / MAIN COMMIT: PR #45.
 --------------------------------------------------------------------------------
 APPENDIX A-06 — Tools: Bitmap + Magnifier
-  STATUS: / DATE: / PER-REQ (006/028/029): / BUILD+TEST: / PR #:
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  REQ-028: IMPLEMENTED — src/ui/tools/BitmapDisplay.tsx:16
+    DIMENSION_OPTIONS = [8, 16, 32, 64, 128, 256]. Browser-verified: the
+    grid <select> renders 8×8 … 256×256.
+  REQ-029: IMPLEMENTED — data-magnify-region on the outer wrappers of
+    RegisterTable, MemoryPanel, ConsolePanel, StatusBar (footer),
+    FpuRegisterTable, MessagesPanel, SymbolsPanel, BreakpointsPanel.
+    Monaco intentionally untagged.
+  REQ-006: IMPLEMENTED — src/ui/tools/ScreenMagnifier.tsx rewritten:
+    240x160 loupe @2x, target resolved in the mousemove handler via
+    elementFromPoint + closest('[data-magnify-region]'), clone effect
+    keyed on TARGET (re-clones only on region change, never per
+    mousemove), interactive elements disarmed + ids stripped in the
+    clone, cursor-centered scale(2) translate, 'Hover a panel to
+    magnify' hint, Escape closes, pointerEvents none throughout.
+    HelpDialog About tab gains a Tools section documenting bitmap sizes
+    + magnifier panels + Monaco limitation + OS-zoom pointer (REQ-042
+    contribution).
+  LIVE BROWSER VERIFICATION (playwright + Edge headless): bitmap options
+    ["8×8","16×16","32×32","64×64","128×128","256×256"]; hovering the
+    register table → loupe contains a cloned [data-magnify-region];
+    hovering Monaco → hint text; Escape → loupe unmounts. Screenshot
+    captured.
+  BUILD+TEST: typecheck 0 / lint 0 (after react-hooks/refs + set-state-
+    in-effect restructures) / build exit 0 / vitest 138/138.
+  PR # / MAIN COMMIT: PR #46.
 --------------------------------------------------------------------------------
 APPENDIX A-07 — Accounts UI
   STATUS: / DATE: / PER-REQ (021): / BUILD+TEST: / PR #:
@@ -885,7 +916,7 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-003 | p.7-8 §2.3 | Backend: DELETE /snippets/{id} owner check, 404 to non-owners | SECURITY | A12 | ⬜ | | pre-exists upstream (verify)
   REQ-004 | p.8 §2.4 | Backend: login failures return 401 'Invalid credentials' (same msg both cases) | FIX | A12 | ⬜ | | pre-exists upstream (verify)
   REQ-005 | p.8-9 §2.5; p.38 §7.1; p.56 §10.1 | Backend secrets: env-var indirection, .env.example, .gitignore, rotation, git-history scrub + force-push + re-clone | SECURITY | A12 | ⬜ | | partial upstream; rotation/scrub = owner
-  REQ-006 | p.9 §2.6; p.46-48 §8.2 | ScreenMagnifier rewrite: DOM-clone loupe 240x160 @2x, hint state, Escape, no per-mousemove reclone, Monaco excluded | FEATURE | A06 | ⬜ | |
+  REQ-006 | p.9 §2.6; p.46-48 §8.2 | ScreenMagnifier rewrite: DOM-clone loupe 240x160 @2x, hint state, Escape, no per-mousemove reclone, Monaco excluded | FEATURE | A06 | IMPLEMENTED | #46 | ScreenMagnifier.tsx rewrite; browser-verified clone/hint/Escape
   REQ-007 | p.10 §2.7; p.20 D1 | Toast system via sonner; Toaster at App root; error/success toasts for API calls | UI/UX | A02 | IMPLEMENTED | #42 | src/App.tsx (Toaster mount); A-02
   REQ-008 | p.10 §2.8 | Loading state on every async button: disabled + spinner/label while in flight; no duplicate submits | UI/UX | A90 | ⬜ | | implemented inline by A07-A10; A90 sweeps
   REQ-009 | p.10-11 §2.9; p.36 §6.6; p.23 D5 | ?snippet=<id> on boot loads snippet into editor; 404 → toast + default example; document title updated | FEATURE | A08 | ⬜ | |
@@ -907,8 +938,8 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-025 | p.40-42 §7.4; p.24 D6 | Run entity + RunRepository: findByUserIdOrderByStartedAtDesc + most-run JPQL projection | FEATURE | A12 | ⬜ | | pre-exists (verify)
   REQ-026 | p.42-43 §7.5; p.24 D6 | SnippetController v1.2: visibility-gated GET, /mine, /public paginated (size cap 100), /save sets owner, PUT update, DELETE owner-checked | FEATURE | A12 | ⬜ | | PUT missing upstream → fork PR
   REQ-027 | p.43-44 §7.6; p.25 D7 | RunController: POST /runs (user from JWT, never from body), GET /runs/recent, GET /runs/most-run, limit caps [+upstream audit C2: add visibility check on POST] | FEATURE | A12 | ⬜ | | pre-exists; C2 fix → fork PR
-  REQ-028 | p.46 §8.1; p.20 D1 | BitmapDisplay DIMENSION_OPTIONS gains 8 and 16; existing sizes unaffected | FEATURE | A06 | ⬜ | |
-  REQ-029 | p.47 §8.2; p.21 D2 | data-magnify-region on RegisterTable, MemoryPanel, ConsolePanel, StatusBar, FpuRegisterTable (+small-text panels); Monaco excluded | FEATURE | A06 | ⬜ | |
+  REQ-028 | p.46 §8.1; p.20 D1 | BitmapDisplay DIMENSION_OPTIONS gains 8 and 16; existing sizes unaffected | FEATURE | A06 | IMPLEMENTED | #46 | BitmapDisplay.tsx:16; browser-verified option list
+  REQ-029 | p.47 §8.2; p.21 D2 | data-magnify-region on RegisterTable, MemoryPanel, ConsolePanel, StatusBar, FpuRegisterTable (+small-text panels); Monaco excluded | FEATURE | A06 | IMPLEMENTED | #46 | 8 panels tagged; A-06
   REQ-030 | p.49 §8.3; p.25 D6 | Run-logging hook: fire-and-forget at run end (COMPLETED/ERROR/ABORTED), runStartedAt duration, skip unauth/unsaved, never block simulator | FEATURE | A10 | ⬜ | |
   REQ-031 | p.51-52 §8.5; p.53 §9.2 | Frontend tests: api.test.ts, persist.test.ts, rem assembler tests in existing harness | TEST | A11 | ⬜ | | authored by A02/A03/A05; A11 verifies completeness
   REQ-032 | p.24-25 D6 | MySnippetsDrawer: /mine list w/ title/updated/visibility badge, click-to-load, edit-in-place title, delete w/ confirm, New Snippet button, currentSnippetId persists | FEATURE | A09 | ⬜ | |

--- a/src/ui/BreakpointsPanel.tsx
+++ b/src/ui/BreakpointsPanel.tsx
@@ -36,7 +36,7 @@ export function BreakpointsPanel() {
   const entries    = useMemo(() => buildEntries(source, breakpoints), [source, breakpoints])
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div data-magnify-region className="flex h-full min-h-0 flex-col">
       <div
         className="flex h-7 flex-none items-center justify-between border-b border-divider px-3 font-mono text-[10px] uppercase text-ink-3"
         style={{ letterSpacing: '0.06em' }}

--- a/src/ui/ConsolePanel.tsx
+++ b/src/ui/ConsolePanel.tsx
@@ -71,7 +71,7 @@ export function ConsolePanel() {
   const showJumpToBottom = !atBottom && hasContent
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div data-magnify-region className="flex h-full min-h-0 flex-col">
       {/* Header (24px): Clear / Copy + filter */}
       <div
         className="flex h-6 flex-none items-center gap-2 border-b border-divider px-2 font-mono text-[10px] uppercase text-ink-3"

--- a/src/ui/FpuRegisterTable.tsx
+++ b/src/ui/FpuRegisterTable.tsx
@@ -27,7 +27,7 @@ export function FpuRegisterTable() {
   const numberBase  = useSimulator((s) => s.numberBase)
 
   return (
-    <div className="flex flex-col gap-2">
+    <div data-magnify-region className="flex flex-col gap-2">
       <div
         className="flex items-center justify-between font-mono text-[10px] uppercase text-ink-3"
         style={{ letterSpacing: '0.06em' }}

--- a/src/ui/HelpDialog.tsx
+++ b/src/ui/HelpDialog.tsx
@@ -245,6 +245,22 @@ export function HelpDialog() {
                     <li>Issues: <a className="text-accent hover:underline" href={ISSUES_URL} target="_blank" rel="noopener noreferrer">{ISSUES_URL}</a></li>
                     <li>License: MIT</li>
                   </ul>
+                  <h3 className="mt-2 text-sm text-ink-1">Tools</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>
+                      <span className="text-ink-1">Bitmap Display</span> — renders a
+                      memory region as pixels. Grid sizes from 8×8 (64 pixels — ideal
+                      for hand-crafted sprites) through 256×256.
+                    </li>
+                    <li>
+                      <span className="text-ink-1">Screen Magnifier</span> — a 2×
+                      loupe that follows the cursor over the register tables, memory
+                      panel, console, messages, symbols, breakpoints, and status bar.
+                      The code editor is intentionally not magnified (its virtual DOM
+                      doesn't clone stably) — use OS-level zoom (Ctrl/Cmd&nbsp;+&nbsp;Plus)
+                      to enlarge code. Escape closes the loupe.
+                    </li>
+                  </ul>
                   <h3 className="mt-2 text-sm text-ink-1">Team</h3>
                   <p>Bryan Djenabia (UI, integration, deployment), Landon Clay (assembler and parser), Zachary Gass (simulator and execution).</p>
                 </div>

--- a/src/ui/MemoryPanel.tsx
+++ b/src/ui/MemoryPanel.tsx
@@ -271,7 +271,7 @@ export function MemoryPanel() {
   }
 
   return (
-    <div className="space-y-2">
+    <div data-magnify-region className="space-y-2">
       {/* Header: segment buttons + base address input */}
       <div className="flex flex-wrap items-center gap-2">
         <div role="group" aria-label="Memory segment" className="inline-flex overflow-hidden rounded-md border border-divider">

--- a/src/ui/MessagesPanel.tsx
+++ b/src/ui/MessagesPanel.tsx
@@ -64,7 +64,7 @@ export function MessagesPanel() {
   const clearMessages = useSimulator((s) => s.clearMessages)
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div data-magnify-region className="flex h-full min-h-0 flex-col">
       <div
         className="flex h-6 flex-none items-center gap-2 border-b border-divider px-2 font-mono text-[10px] uppercase text-ink-3"
         style={{ letterSpacing: '0.06em' }}

--- a/src/ui/RegisterTable.tsx
+++ b/src/ui/RegisterTable.tsx
@@ -169,7 +169,7 @@ export function RegisterTable() {
     : 0
 
   return (
-    <div className="space-y-3">
+    <div data-magnify-region className="space-y-3">
       <BaseToggle />
 
       <div className="overflow-hidden rounded-md border border-divider bg-surface-1 font-mono">

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -27,6 +27,7 @@ export function StatusBar() {
 
   return (
     <footer
+      data-magnify-region
       className="grid h-6 grid-cols-[auto_1fr_auto] items-center border-t border-divider bg-surface-1 font-mono text-xs uppercase"
     >
       {/* Left: current sim status */}

--- a/src/ui/SymbolsPanel.tsx
+++ b/src/ui/SymbolsPanel.tsx
@@ -106,7 +106,7 @@ export function SymbolsPanel() {
   }, [entries])
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div data-magnify-region className="flex h-full min-h-0 flex-col">
       <div
         className="flex h-7 flex-none items-center justify-between border-b border-divider px-3 font-mono text-[10px] uppercase text-ink-3"
         style={{ letterSpacing: '0.06em' }}

--- a/src/ui/tools/BitmapDisplay.tsx
+++ b/src/ui/tools/BitmapDisplay.tsx
@@ -13,7 +13,7 @@ import { cn } from '../cn.ts'
 // tool is open but the user isn't interested.
 
 const CELL_SIZE_OPTIONS = [1, 2, 4, 8, 16, 32] as const
-const DIMENSION_OPTIONS = [32, 64, 128, 256] as const
+const DIMENSION_OPTIONS = [8, 16, 32, 64, 128, 256] as const
 
 const DEFAULT_BASE = 0x10010000
 

--- a/src/ui/tools/ScreenMagnifier.tsx
+++ b/src/ui/tools/ScreenMagnifier.tsx
@@ -1,14 +1,17 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useSimulator } from '@/hooks/useSimulator.ts'
 
-// Phase 3 SA-15: a 200x150 px floating loupe that follows the cursor
-// and shows the page underneath at 2x via CSS background-image. No
-// engine impact, no canvas — pure DOM scrolling that never traps
-// the cursor.
+// Phase 3 SA-15 rewrite (Enhancement Plan §8.2): a floating loupe that
+// magnifies the panel under the cursor via DOM cloning. The element
+// tagged data-magnify-region under the pointer is cloned into the loupe
+// and rendered at 2x with a CSS transform — no html2canvas, no canvas
+// rasterization. Re-clones ONLY when the target region changes, not on
+// every mousemove, so there is no per-frame DOM churn.
 //
-// Activated by Tools menu → Screen Magnifier (toggle). Press Esc or
-// toggle the menu item again to dismiss. Useful for projector
-// demos where students at the back can't see the editor's font.
+// Activated by Tools menu → Screen Magnifier (toggle). Esc dismisses.
+// The Monaco editor is intentionally NOT tagged — its virtualized DOM
+// doesn't survive a stable clone; hovering it shows the hint instead
+// (the Help dialog points those users at OS-level zoom).
 
 const ZOOM = 2
 const SIZE_W = 240
@@ -18,11 +21,24 @@ export function ScreenMagnifier() {
   const on     = useSimulator((s) => s.screenMagnifierOn)
   const toggle = useSimulator((s) => s.toggleScreenMagnifier)
   const [pos, setPos] = useState({ x: 0, y: 0 })
+  // The region under the cursor. Held in state (not a ref) because the
+  // render pass positions the clone from its bounding rect.
+  const [target, setTarget] = useState<Element | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
 
+  // Mouse and Escape wiring. The target region is resolved inside the
+  // mousemove handler: closest() walks to the region root, so small
+  // movements within the same panel resolve to the SAME element and
+  // the state set is a no-op (no re-clone, no re-render churn). The
+  // loupe itself has pointerEvents: none, so elementFromPoint never
+  // lands on it.
   useEffect(() => {
     if (!on) return
     function handleMove(event: MouseEvent) {
       setPos({ x: event.clientX, y: event.clientY })
+      const under = document.elementFromPoint(event.clientX, event.clientY)
+      const next = under?.closest('[data-magnify-region]') ?? null
+      setTarget((prev) => (prev === next ? prev : next))
     }
     function handleKey(event: KeyboardEvent) {
       if (event.key === 'Escape') toggle()
@@ -32,8 +48,28 @@ export function ScreenMagnifier() {
     return () => {
       window.removeEventListener('mousemove', handleMove)
       window.removeEventListener('keydown', handleKey)
+      setTarget(null)
     }
   }, [on, toggle])
+
+  // Clone the target into the loupe — runs only when the TARGET
+  // changes, never per mousemove.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    container.innerHTML = ''
+    if (!target) return
+    const cloned = target.cloneNode(true) as HTMLElement
+    // The clone is a visual snapshot — disarm anything interactive so
+    // nothing inside it can receive events, and strip ids so the page
+    // keeps unique ids.
+    cloned.querySelectorAll('button, input, select, textarea, a').forEach((el) => {
+      ;(el as HTMLElement).style.pointerEvents = 'none'
+      el.removeAttribute('id')
+    })
+    cloned.removeAttribute('id')
+    container.appendChild(cloned)
+  }, [target])
 
   if (!on) return null
 
@@ -41,6 +77,12 @@ export function ScreenMagnifier() {
   // sit underneath the user's pointer. Clamp inside the viewport.
   const clientX = Math.min(window.innerWidth - SIZE_W - 12, pos.x + 24)
   const clientY = Math.min(window.innerHeight - SIZE_H - 12, pos.y + 24)
+
+  // Translate so the cursor's position inside the source region lands
+  // centered in the loupe at ZOOM scale.
+  const rect = target?.getBoundingClientRect()
+  const tx = rect ? -(pos.x - rect.left) + SIZE_W / (2 * ZOOM) : 0
+  const ty = rect ? -(pos.y - rect.top) + SIZE_H / (2 * ZOOM) : 0
 
   return (
     <div
@@ -54,33 +96,26 @@ export function ScreenMagnifier() {
         pointerEvents: 'none',
         zIndex: 70,
         border: '2px solid var(--accent)',
-        borderRadius: '8px',
+        borderRadius: 'var(--radius-lg)',
         boxShadow: '0 12px 40px rgba(0,0,0,0.45)',
         overflow: 'hidden',
         background: 'var(--surface-elev)',
       }}
     >
-      {/* The "magnified" content is a CSS-scaled clone of the page
-         body, positioned so the cursor's location is centered. We
-         use transform: scale + translate; precise but cheap. */}
       <div
+        ref={containerRef}
         style={{
-          width:  SIZE_W / ZOOM,
-          height: SIZE_H / ZOOM,
-          transform: `scale(${ZOOM}) translate(${-pos.x + (SIZE_W / (2 * ZOOM))}px, ${-pos.y + (SIZE_H / (2 * ZOOM))}px)`,
+          transform: `scale(${ZOOM}) translate(${tx}px, ${ty}px)`,
           transformOrigin: '0 0',
+          pointerEvents: 'none',
+          display: target ? undefined : 'none',
         }}
-        // Inline a clone via a CSS background-image-like trick is
-        // complex; use a simplified alternative: render an
-        // informational placeholder. The full page-clone approach
-        // requires html2canvas or postprocessing; out of scope for
-        // SA-15. Educators can use OS-level zoom for now and the
-        // loupe stands as a pointer aid.
-      >
-        <div className="flex h-full w-full items-center justify-center text-[10px] text-ink-3">
-          Magnifier overlay (cursor at {pos.x},{pos.y})
+      />
+      {!target && (
+        <div className="flex h-full w-full items-center justify-center px-3 text-center text-[11px] text-ink-3">
+          Hover a panel to magnify
         </div>
-      </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Agent
AGENT 06 - Tools: Bitmap Grid Sizes + Screen Magnifier (loop position: 7 of 18)

## Requirements delivered
- REQ-028 - BitmapDisplay 8x8 and 16x16 grid options
- REQ-029 - data-magnify-region tags on 8 panels (registers, memory, console, status bar, FPU, messages, symbols, breakpoints)
- REQ-006 - ScreenMagnifier rewritten from placeholder to a working DOM-clone loupe

## What changed and why
Enhancement Plan sections 2.6, 8.1, 8.2. The magnifier resolves its target in the mousemove handler (closest data-magnify-region) and re-clones ONLY when the target region changes - no per-mousemove DOM churn. Interactive elements in the clone are disarmed and ids stripped. Monaco stays untagged by design (virtualized DOM); the Help dialog documents the limitation and points at OS zoom.

## Evidence summary
- Live browser (playwright + Edge headless): options [8x8..256x256]; register-table hover -> clone present in loupe; Monaco hover -> 'Hover a panel to magnify'; Escape closes
- Build/typecheck/lint exit 0; tests 138/138