### PR TITLE
agent-07: account auth slice, AuthModal, toolbar auth UI

### DIFF
--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -163,7 +163,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   AGENT 04 — Monaco Light Theme + System Preference ............. ✅ COMPLETE
   AGENT 05 — rem Pseudo-Instruction (Assembler + Tests) ......... ✅ COMPLETE
   AGENT 06 — Tools: Bitmap Grid Sizes + Screen Magnifier ........ ✅ COMPLETE
-  AGENT 07 — Accounts UI: Auth Slice + AuthModal + Toolbar ...... ⬜ NOT STARTED
+  AGENT 07 — Accounts UI: Auth Slice + AuthModal + Toolbar ...... ✅ COMPLETE
   AGENT 08 — Save, Share & Deep Links (?snippet=<id>) ........... ⬜ NOT STARTED
   AGENT 09 — My Snippets Drawer + Public Feed ................... ⬜ NOT STARTED
   AGENT 10 — Run History: Logging Hook + HistoryPanel ........... ⬜ NOT STARTED
@@ -241,7 +241,14 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   options; 8 panels tagged data-magnify-region; ScreenMagnifier rewritten
   as DOM-clone loupe (re-clone only on target change). Live browser
   proof: options list, clone-present on register table hover, hint on
-  Monaco hover, Escape closes. 138/138 green. PR #46.
+  Monaco hover, Escape closes. 138/138 green. PR #46 merged, main @
+  ac3f2c7.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 07: accounts UI (REQ-021) done. Auth slice + AuthModal
+  + toolbar/mobile affordances. LIVE production round-trip proven against
+  the Railway API: register→login→refresh-persist→logout→401-toast→login.
+  Q2 catch: mobile drawer gained the System theme option (REQ-002-EXT-1).
+  138/138 green. PR #47.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -878,7 +885,34 @@ APPENDIX A-06 — Tools: Bitmap + Magnifier
   PR # / MAIN COMMIT: PR #46.
 --------------------------------------------------------------------------------
 APPENDIX A-07 — Accounts UI
-  STATUS: / DATE: / PER-REQ (021): / BUILD+TEST: / PR #:
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  REQ-021: IMPLEMENTED —
+    src/hooks/useSimulator.ts: auth slice (authToken/authUsername mirroring
+      webmars.token/webmars.username — the exact keys api.ts reads;
+      setAuth/clearAuth; authModalOpen + open/close), privacy-mode-safe
+      read/write helpers.
+    src/ui/AuthModal.tsx: NEW — Login/Register tabs, busy state disabling
+      inputs + submit, error map (400 parses the GlobalExceptionHandler
+      field map; 401 'Wrong username or password.'; 409 'That username is
+      taken.'; 429 'Too many attempts…'; network fallback), register
+      auto-signs-in, Tab focus trap + Escape close + Enter submit
+      (REQ-037 pattern), initial focus on username.
+    src/ui/Toolbar.tsx: AuthMenu — 'Sign in' button ↔ ●username menu with
+      Log out (portal pattern mirroring ExamplesDropdown).
+    src/ui/MobileShell.tsx: Account drawer section (Sign in / Log out) +
+      System theme item (Q2 catch: the mobile theme list was a second
+      theme-picker instance REQ-002 implied — recorded as REQ-002-EXT-1).
+    src/ui/Shell.tsx: AuthModal mounted on desktop AND mobile paths.
+  LIVE PRODUCTION VERIFICATION (playwright + Edge headless, dev server
+    pointed at https://webmars-api-production.up.railway.app via
+    .env.local): register 200 → auto-login 200 → toolbar shows username;
+    reload → still signed in; Log out → Sign in returns; wrong password →
+    401 + 'Wrong username or password.' toast; correct login 200 → signed
+    in. Network log captured (register/login statuses). Discovered live:
+    usernames must match ^[a-zA-Z0-9_]+$ (backend @Pattern) — 400 path
+    exercised and mapped.
+  BUILD+TEST: typecheck 0 / lint 0 / build exit 0 / vitest 138/138.
+  PR # / MAIN COMMIT: PR #47.
 --------------------------------------------------------------------------------
 APPENDIX A-08 — Save, Share & Deep Links
   STATUS: / DATE: / PER-REQ (009/022/038): / BUILD+TEST: / PR #:
@@ -931,7 +965,8 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-018 | p.16 §3.6.2; p.20 D1 | Frontend env-aware API base: VITE_API_BASE w/ localhost fallback; .env.local.example | INFRA | A02 | IMPLEMENTED | #42 | src/lib/api.ts:6; .env.local.example
   REQ-019 | p.16 §3.6.2; p.27 D10; p.56 §10.1 | Vercel env var VITE_API_BASE set + production redeploy + deployed-combo CORS check | INFRA | A92 | ⬜ | | dashboard = owner unless CLI authed
   REQ-020 | p.30-32 §6.1 | src/lib/api.ts typed client: ApiError, authHeader, request<T> w/ 204, full auth/snippets/runs surface per skeleton | FEATURE | A02 | IMPLEMENTED | #42 | src/lib/api.ts; src/tests/api.test.ts (5 tests)
-  REQ-021 | p.34-35 §6.4; p.22 D4 | Auth slice (webmars.token/webmars.username) + AuthModal (tabs, busy, 401/409/429/network msg map) + toolbar Sign-in/username/Log-out | FEATURE | A07 | ⬜ | |
+  REQ-021 | p.34-35 §6.4; p.22 D4 | Auth slice (webmars.token/webmars.username) + AuthModal (tabs, busy, 401/409/429/network msg map) + toolbar Sign-in/username/Log-out | FEATURE | A07 | IMPLEMENTED | #47 | AuthModal.tsx; live prod round-trip in A-07
+  REQ-002-EXT-1 | (Q2 of REQ-002) | Mobile drawer theme list gains the System option (second theme-picker instance) | FIX | A07 | IMPLEMENTED | #47 | MobileShell.tsx theme section
   REQ-022 | p.36 §6.5; p.23 D5 | Save-to-Account + ShareModal: create-vs-update semantics, copy link + toast, visibility shown + toggle → PUT | FEATURE | A08 | ⬜ | |
   REQ-023 | p.44-45 §7.7; p.22-24 D4-D5 | rem pseudo-instruction: lexer mnemonic, parser ["R","R","R"], assembler div+mfhi expansion [live assembler is instructions.ts; PDF-named files also updated] | FEATURE | A05 | IMPLEMENTED | #45 | instructions.ts rem case; pseudoInstructions.test.ts +4 tests
   REQ-024 | p.40 §7.3; p.24 D5 | Snippet entity v1.2: owner FK lazy, Visibility enum STRING, created/updated timestamps + lifecycle hooks | FEATURE | A12 | ⬜ | | pre-exists (verify)

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { TOKEN_STORAGE_KEY, USERNAME_STORAGE_KEY } from '../lib/api.ts'
 import { Simulator } from '../core/simulator.ts'
 import { assemble } from '../core/instructions.ts'
 import { REGISTER_NAMES } from '../core/registers.ts'
@@ -283,6 +284,29 @@ function makeFileId(): string {
     return crypto.randomUUID()
   }
   return `file-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+}
+
+// ─ auth persistence (Enhancement Plan §6.4) ─
+//
+// Keys shared with src/lib/api.ts, which reads webmars.token on every
+// request to attach the Authorization header.
+
+function readAuthValue(key: string): string | null {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function writeAuthValue(key: string, value: string | null): void {
+  try {
+    if (typeof window === 'undefined') return
+    if (value === null) window.localStorage.removeItem(key)
+    else window.localStorage.setItem(key, value)
+  } catch {
+    // ignore — privacy mode; the session just won't survive a refresh
+  }
 }
 
 // ─ workspace persistence ─
@@ -721,6 +745,17 @@ interface SimulatorStoreState {
   commandPaletteOpen: boolean
   openCommandPalette:  () => void
   closeCommandPalette: () => void
+
+  // ─ auth slice (Enhancement Plan §6.4; token/username persisted to
+  //   webmars.token / webmars.username — the same keys src/lib/api.ts
+  //   reads to attach the Authorization header) ─
+  authToken: string | null
+  authUsername: string | null
+  authModalOpen: boolean
+  setAuth: (token: string, username: string) => void
+  clearAuth: () => void
+  openAuthModal: () => void
+  closeAuthModal: () => void
 
   // ─ layoutSizes slice (Phase 3 SA-5; persisted to webmars:layout-sizes) ─
   // Drag-handle sizes for the three resizable Shell regions. The
@@ -1319,6 +1354,24 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
     commandPaletteOpen: false,
     openCommandPalette:  () => set({ commandPaletteOpen: true  }),
     closeCommandPalette: () => set({ commandPaletteOpen: false }),
+
+    // auth slice — token/username mirror localStorage so api.ts (which
+    // reads webmars.token directly) and the UI stay in sync.
+    authToken: readAuthValue(TOKEN_STORAGE_KEY),
+    authUsername: readAuthValue(USERNAME_STORAGE_KEY),
+    authModalOpen: false,
+    setAuth: (token, username) => {
+      writeAuthValue(TOKEN_STORAGE_KEY, token)
+      writeAuthValue(USERNAME_STORAGE_KEY, username)
+      set({ authToken: token, authUsername: username })
+    },
+    clearAuth: () => {
+      writeAuthValue(TOKEN_STORAGE_KEY, null)
+      writeAuthValue(USERNAME_STORAGE_KEY, null)
+      set({ authToken: null, authUsername: null })
+    },
+    openAuthModal:  () => set({ authModalOpen: true  }),
+    closeAuthModal: () => set({ authModalOpen: false }),
 
     layoutSizes: readPersistedLayoutSizes(),
     setLayoutSize: (key, value) => {

--- a/src/ui/AuthModal.tsx
+++ b/src/ui/AuthModal.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import * as api from '@/lib/api.ts'
+import { useSimulator } from '@/hooks/useSimulator.ts'
+import { cn } from './cn.ts'
+
+// Enhancement Plan §6.4 — a single dialog with Login and Register tabs.
+// Submits to the backend via src/lib/api.ts, stores the token in
+// localStorage (via the store's auth slice), and updates the UI.
+// Keyboard contract (plan D9): focus lands inside on open, Tab cycles
+// within the dialog, Enter submits, Escape closes.
+
+type Mode = 'login' | 'register'
+
+function friendlyAuthError(err: unknown): string {
+  if (err instanceof api.ApiError) {
+    switch (err.status) {
+      case 400: {
+        // GlobalExceptionHandler returns a field → message JSON map.
+        try {
+          const body = JSON.parse(err.body) as Record<string, string>
+          const first = Object.values(body)[0]
+          if (typeof first === 'string' && first.length > 0) return first
+        } catch {
+          // fall through to the generic message
+        }
+        return 'Check your username and password format.'
+      }
+      case 401: return 'Wrong username or password.'
+      case 409: return 'That username is taken.'
+      case 429: return 'Too many attempts. Try again in a few minutes.'
+      default:  return 'Something went wrong. Please try again.'
+    }
+  }
+  return 'Network error. Check your connection.'
+}
+
+export function AuthModal() {
+  const open = useSimulator((s) => s.authModalOpen)
+  const close = useSimulator((s) => s.closeAuthModal)
+  const setAuth = useSimulator((s) => s.setAuth)
+
+  const [mode, setMode] = useState<Mode>('login')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [busy, setBusy] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const usernameRef = useRef<HTMLInputElement>(null)
+
+  // Escape closes; initial focus lands on the username field; Tab is
+  // trapped inside the dialog while it is open.
+  useEffect(() => {
+    if (!open) return
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        close()
+        return
+      }
+      if (event.key === 'Tab' && dialogRef.current) {
+        const focusables = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button, input, [tabindex]:not([tabindex="-1"])',
+        )
+        if (focusables.length === 0) return
+        const first = focusables[0]!
+        const last = focusables[focusables.length - 1]!
+        const active = document.activeElement
+        if (event.shiftKey && (active === first || !dialogRef.current.contains(active))) {
+          event.preventDefault()
+          last.focus()
+        } else if (!event.shiftKey && active === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    usernameRef.current?.focus()
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [open, close])
+
+  if (!open) return null
+
+  async function submit() {
+    if (busy) return
+    const name = username.trim()
+    if (name.length === 0 || password.length === 0) {
+      toast.error('Enter a username and password.')
+      return
+    }
+    setBusy(true)
+    try {
+      if (mode === 'register') {
+        await api.register(name, password)
+        toast.success('Account created. Signing you in…')
+      }
+      const { token } = await api.login(name, password)
+      setAuth(token, name)
+      toast.success(`Signed in as ${name}`)
+      setUsername('')
+      setPassword('')
+      close()
+    } catch (err) {
+      toast.error(friendlyAuthError(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) close()
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={mode === 'login' ? 'Sign in' : 'Create account'}
+        className="w-full max-w-sm overflow-hidden rounded-lg border border-divider bg-surface-1 shadow-xl"
+      >
+        {/* Tab strip — Login / Register */}
+        <div role="tablist" aria-label="Authentication mode" className="flex border-b border-divider">
+          {(['login', 'register'] as const).map((m) => (
+            <button
+              key={m}
+              role="tab"
+              type="button"
+              aria-selected={mode === m}
+              onClick={() => setMode(m)}
+              className={cn(
+                'flex-1 px-4 py-2.5 text-xs font-medium transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent',
+                mode === m
+                  ? 'bg-surface-2 text-ink-1'
+                  : 'text-ink-3 hover:bg-surface-2 hover:text-ink-2',
+              )}
+            >
+              {m === 'login' ? 'Sign in' : 'Register'}
+            </button>
+          ))}
+        </div>
+
+        <form
+          className="flex flex-col gap-3 px-5 py-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void submit()
+          }}
+        >
+          <label className="flex flex-col gap-1">
+            <span className="font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+              Username
+            </span>
+            <input
+              ref={usernameRef}
+              type="text"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              autoComplete="username"
+              minLength={3}
+              maxLength={32}
+              disabled={busy}
+              className="rounded-sm border border-divider bg-surface-0 px-2 py-1.5 text-xs text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+              Password
+            </span>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete={mode === 'register' ? 'new-password' : 'current-password'}
+              minLength={8}
+              disabled={busy}
+              className="rounded-sm border border-divider bg-surface-0 px-2 py-1.5 text-xs text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            />
+          </label>
+
+          <div className="mt-1 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={close}
+              disabled={busy}
+              className="rounded-sm px-3 py-1.5 text-xs text-ink-2 transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy}
+              className={cn(
+                'rounded-sm bg-accent px-3 py-1.5 text-xs font-medium text-surface-0 transition-opacity',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1',
+                busy && 'cursor-not-allowed opacity-60',
+              )}
+            >
+              {busy
+                ? mode === 'login' ? 'Signing in…' : 'Creating account…'
+                : mode === 'login' ? 'Sign in' : 'Create account'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/MobileShell.tsx
+++ b/src/ui/MobileShell.tsx
@@ -54,6 +54,9 @@ function Drawer({ open, onClose }: { open: boolean; onClose: () => void }) {
   const openHelp        = useSimulator((s) => s.openHelp)
   const setTheme        = useSimulator((s) => s.setTheme)
   const theme           = useSimulator((s) => s.theme)
+  const authUsername    = useSimulator((s) => s.authUsername)
+  const openAuthModal   = useSimulator((s) => s.openAuthModal)
+  const clearAuth       = useSimulator((s) => s.clearAuth)
 
   if (!open) return null
 
@@ -93,10 +96,18 @@ function Drawer({ open, onClose }: { open: boolean; onClose: () => void }) {
           <DrawerItem label="Syscall I/O"    onClick={() => { loadFromExample('syscallIO');   close() }} />
           <DrawerItem label="Float Math"     onClick={() => { loadFromExample('floatMath');   close() }} />
 
+          <DrawerSection title="Account" />
+          {authUsername === null ? (
+            <DrawerItem label="Sign in" onClick={() => { openAuthModal(); close() }} />
+          ) : (
+            <DrawerItem label={`Log out (${authUsername})`} onClick={() => { clearAuth(); close() }} />
+          )}
+
           <DrawerSection title="Theme" />
           <DrawerItem label={`Dark${theme==='dark'?' ✓':''}`}            onClick={() => { setTheme('dark') }} />
           <DrawerItem label={`Light${theme==='light'?' ✓':''}`}          onClick={() => { setTheme('light') }} />
           <DrawerItem label={`High Contrast${theme==='hc'?' ✓':''}`}     onClick={() => { setTheme('hc') }} />
+          <DrawerItem label={`System${theme==='system'?' ✓':''}`}       onClick={() => { setTheme('system') }} />
 
           <DrawerSection title="Other" />
           <DrawerItem label="Settings"           onClick={() => { openSettings(); close() }} />

--- a/src/ui/Shell.tsx
+++ b/src/ui/Shell.tsx
@@ -12,6 +12,7 @@ import { SourcePane } from './SourcePane.tsx'
 import { StatusBar } from './StatusBar.tsx'
 import { DevPanel } from './DevPanel.tsx'
 import { SettingsDialog } from './SettingsDialog.tsx'
+import { AuthModal } from './AuthModal.tsx'
 import { CommandPalette } from './CommandPalette.tsx'
 import { InstructionCounter } from './InstructionCounter.tsx'
 import { HelpDialog } from './HelpDialog.tsx'
@@ -101,6 +102,7 @@ export function Shell() {
     return (
       <>
         <MobileShell />
+        <AuthModal />
         {import.meta.env.DEV && <DevPanel />}
       </>
     )
@@ -162,6 +164,7 @@ export function Shell() {
       </div>
       {import.meta.env.DEV && <DevPanel />}
       <SettingsDialog />
+      <AuthModal />
       <CommandPalette />
       <InstructionCounter />
       <HelpDialog />

--- a/src/ui/Toolbar.tsx
+++ b/src/ui/Toolbar.tsx
@@ -203,6 +203,104 @@ function Divider() {
   return <span aria-hidden="true" className="mx-1 h-6 w-px bg-divider" />
 }
 
+// Enhancement Plan §6.4: Sign-in affordance. Logged out → a "Sign in"
+// button opening the AuthModal. Logged in → the username with a small
+// menu holding "Log out". Mirrors the ExamplesDropdown portal pattern.
+function AuthMenu() {
+  const authUsername  = useSimulator((s) => s.authUsername)
+  const openAuthModal = useSimulator((s) => s.openAuthModal)
+  const clearAuth     = useSimulator((s) => s.clearAuth)
+  const [open, setOpen] = useState(false)
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node
+      if (
+        buttonRef.current && !buttonRef.current.contains(target) &&
+        menuRef.current && !menuRef.current.contains(target)
+      ) {
+        setOpen(false)
+      }
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('mousedown', handleClickOutside)
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('mousedown', handleClickOutside)
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  useLayoutEffect(() => {
+    if (!open || !buttonRef.current) return
+    const rect = buttonRef.current.getBoundingClientRect()
+    setPos({ left: Math.max(8, rect.right - 160), top: rect.bottom + 4 })
+  }, [open])
+
+  if (!authUsername) {
+    return (
+      <button
+        type="button"
+        onClick={openAuthModal}
+        className="mr-1 rounded-sm bg-surface-2 px-2 py-1 text-xs font-medium text-ink-1 transition-colors hover:bg-surface-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        Sign in
+      </button>
+    )
+  }
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+        title={`Signed in as ${authUsername}`}
+        className={cn(
+          'mr-1 flex items-center gap-1 rounded-sm px-2 py-1 text-xs font-medium transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+          open ? 'bg-surface-3 text-ink-1' : 'bg-surface-2 text-ink-1 hover:bg-surface-3',
+        )}
+      >
+        <span aria-hidden="true" className="text-accent">●</span>
+        {authUsername}
+        <span aria-hidden="true" className="text-[10px] text-ink-3">▾</span>
+      </button>
+
+      {open && pos && createPortal(
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Account"
+          style={{ position: 'fixed', left: pos.left, top: pos.top }}
+          className="z-[60] min-w-[10rem] rounded-md border border-divider bg-surface-elev py-1 shadow-lg"
+        >
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => {
+              clearAuth()
+              setOpen(false)
+            }}
+            className="block w-full px-3 py-1.5 text-left text-xs text-ink-2 hover:bg-surface-3 hover:text-ink-1 focus-visible:outline-none focus-visible:bg-surface-3"
+          >
+            Log out
+          </button>
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+}
+
 export function Toolbar() {
   const source        = useSimulator((s) => s.source)
   const assemble      = useSimulator((s) => s.assemble)
@@ -345,6 +443,9 @@ export function Toolbar() {
 
       {/* Right side: spacer pushes StatusPill to the far edge. */}
       <span className="flex-1" aria-hidden="true" />
+
+      {/* Enhancement Plan §6.4: account sign-in / username menu. */}
+      <AuthMenu />
 
       {/* Phase 3 SA-6: ? button opens the help dialog. F1 also
          opens it via the global keybinding map. */}


### PR DESCRIPTION
## Agent
AGENT 07 - Accounts UI (loop position: 8 of 18)

## Requirements delivered
- REQ-021 - auth slice (webmars.token/webmars.username), AuthModal with Login/Register tabs, toolbar Sign-in <-> username menu with Log out, mobile drawer parity
- REQ-002-EXT-1 - mobile theme list gains the System option (Q2 catch)

## What changed and why
Enhancement Plan section 6.4. The auth slice mirrors the exact localStorage keys the API client reads, so the Authorization header and the UI can never disagree. AuthModal maps failure statuses to friendly copy (401/409/429/400-field-map/network), disables inputs while busy, auto-signs-in after register, and implements the D9 keyboard contract (focus trap, Escape, Enter).

## Evidence summary
- LIVE production round-trip against webmars-api-production.up.railway.app: register 200 -> auto-login -> username in toolbar -> survives reload -> logout -> wrong password 401 toast -> login 200
- Build/typecheck/lint exit 0; tests 138/138

## Out of scope / follow-ups
Backend username rule ^[a-zA-Z0-9_]+\$ discovered live; AuthModal surfaces the server's field message on 400.