### PR TITLE
agent-08: snippet save/share modal + deep-link loading

### DIFF
--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -164,7 +164,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   AGENT 05 — rem Pseudo-Instruction (Assembler + Tests) ......... ✅ COMPLETE
   AGENT 06 — Tools: Bitmap Grid Sizes + Screen Magnifier ........ ✅ COMPLETE
   AGENT 07 — Accounts UI: Auth Slice + AuthModal + Toolbar ...... ✅ COMPLETE
-  AGENT 08 — Save, Share & Deep Links (?snippet=<id>) ........... ⬜ NOT STARTED
+  AGENT 08 — Save, Share & Deep Links (?snippet=<id>) ........... ✅ COMPLETE
   AGENT 09 — My Snippets Drawer + Public Feed ................... ⬜ NOT STARTED
   AGENT 10 — Run History: Logging Hook + HistoryPanel ........... ⬜ NOT STARTED
   AGENT 11 — Polish, A11y, Docs, Tests Completion, v1.3 Issues .. ⬜ NOT STARTED
@@ -248,7 +248,17 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   + toolbar/mobile affordances. LIVE production round-trip proven against
   the Railway API: register→login→refresh-persist→logout→401-toast→login.
   Q2 catch: mobile drawer gained the System theme option (REQ-002-EXT-1).
-  138/138 green. PR #47.
+  138/138 green. PR #47 merged, main @ 9b4d9ce.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 08: save/share/deep links (REQ-009/022/038) done.
+  SaveSnippetDialog + ShareModal + toolbar Save/Share; ?snippet= boot
+  loading + popstate; snippet metadata persisted with workspace. LIVE:
+  save 200 → ShareModal → clipboard verified; 404 → exact plan toast +
+  default example. ⚠ Discovered production backend bug: GET /snippets/
+  {id} and the populated public feed return 500 (lazy owner proxy +
+  open-in-view=false) — share links/feed are DOWN upstream; fix (plan's
+  own SnippetResponse DTO) routed to AGENT 12's fork PR. 138/138 green.
+  PR #48.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -915,7 +925,41 @@ APPENDIX A-07 — Accounts UI
   PR # / MAIN COMMIT: PR #47.
 --------------------------------------------------------------------------------
 APPENDIX A-08 — Save, Share & Deep Links
-  STATUS: / DATE: / PER-REQ (009/022/038): / BUILD+TEST: / PR #:
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  REQ-022: IMPLEMENTED — snippet slice in useSimulator (currentSnippetId/
+    Title/Visibility persisted with the workspace payload; persist.test
+    updated to the new shape); SaveSnippetDialog.tsx (title prefill from
+    active file, PRIVATE default, busy state, keyboard contract);
+    ShareModal.tsx (link + Copy via clipboard + toast, visibility display
+    + toggle → PUT with explanatory failure toast); Toolbar
+    SaveShareButtons (authed-only; create → dialog → ShareModal, update
+    → PUT in place, Share reopens modal). LIVE: save 200 → ShareModal →
+    copy toast + clipboard round-trip verified; PUT toggle fails
+    gracefully with explanation (upstream endpoint not live).
+  REQ-009: IMPLEMENTED — router.ts getSnippetIdFromUrl/setSnippetIdInUrl;
+    App.tsx useSnippetDeepLink (boot fetch + document.title + toasts).
+    LIVE: /?snippet=999999 → exact plan toast 'That snippet is private or
+    does not exist.' + default hello example in the editor (view-lines
+    text asserted); upstream-500 case → 'Failed to load shared snippet.'
+    + app remains usable.
+  REQ-038: IMPLEMENTED — popstate handler syncs binding: pushState to /
+    clears (Share button disappears, verified); back restores URL and
+    re-issues GET (verified fired) — full state restore currently
+    blocked LIVE by the upstream 500 below; holds once fixed (A91 Q1
+    re-verifies).
+  ⚠ UPSTREAM BUG DISCOVERED (routed to A12): production GET
+    /snippets/{id} returns 500 for ANY existing snippet (owner or anon,
+    public or private), and GET /snippets/public 500s once rows exist —
+    Snippet.owner is FetchType.LAZY, spring.jpa.open-in-view=false, and
+    Jackson serializes the closed-session proxy →
+    LazyInitializationException. Missing ids correctly 404. Evidence:
+    api-probe scripts (saved id 6 private + id 7 public; GET both → 500
+    {"Error":"An unexpected error occurred…"}; GET 999999 → 404; feed
+    with rows → 500). Share/feed features are DOWN in production until
+    fixed — the plan's own SnippetResponse DTO (§7.5) is the fix; ships
+    in A12's fork PR.
+  BUILD+TEST: typecheck 0 / lint 0 / build exit 0 / vitest 138/138.
+  PR # / MAIN COMMIT: PR #48.
 --------------------------------------------------------------------------------
 APPENDIX A-09 — My Snippets + Public Feed
   STATUS: / DATE: / PER-REQ (032/033): / BUILD+TEST: / PR #:
@@ -953,7 +997,7 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-006 | p.9 §2.6; p.46-48 §8.2 | ScreenMagnifier rewrite: DOM-clone loupe 240x160 @2x, hint state, Escape, no per-mousemove reclone, Monaco excluded | FEATURE | A06 | IMPLEMENTED | #46 | ScreenMagnifier.tsx rewrite; browser-verified clone/hint/Escape
   REQ-007 | p.10 §2.7; p.20 D1 | Toast system via sonner; Toaster at App root; error/success toasts for API calls | UI/UX | A02 | IMPLEMENTED | #42 | src/App.tsx (Toaster mount); A-02
   REQ-008 | p.10 §2.8 | Loading state on every async button: disabled + spinner/label while in flight; no duplicate submits | UI/UX | A90 | ⬜ | | implemented inline by A07-A10; A90 sweeps
-  REQ-009 | p.10-11 §2.9; p.36 §6.6; p.23 D5 | ?snippet=<id> on boot loads snippet into editor; 404 → toast + default example; document title updated | FEATURE | A08 | ⬜ | |
+  REQ-009 | p.10-11 §2.9; p.36 §6.6; p.23 D5 | ?snippet=<id> on boot loads snippet into editor; 404 → toast + default example; document title updated | FEATURE | A08 | IMPLEMENTED | #48 | App.tsx useSnippetDeepLink; live 404-toast + fallback verified (A-08)
   REQ-010 | p.11 §2.10; p.26 D8 | JWT expiry 8h (sprint choice) + README v1.3 note re refresh tokens | FIX | A12 | ⬜ | | 8h pre-exists (verify note)
   REQ-011 | p.11 §2.11; p.39 §7.2; p.56 §10.1 | CORS: prod + localhost origins, methods, headers, credentials, no wildcards | FIX | A12 | ⬜ | | pre-exists upstream (verify)
   REQ-012 | p.12-14 §3.2-3.4 | Flyway versioned migrations; final schema users/snippets(owner,visibility,updated_at,indexes)/runs(indexes) | INFRA | A12 | ⬜ | | V1-V4 pre-exist (verify contents)
@@ -967,7 +1011,7 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-020 | p.30-32 §6.1 | src/lib/api.ts typed client: ApiError, authHeader, request<T> w/ 204, full auth/snippets/runs surface per skeleton | FEATURE | A02 | IMPLEMENTED | #42 | src/lib/api.ts; src/tests/api.test.ts (5 tests)
   REQ-021 | p.34-35 §6.4; p.22 D4 | Auth slice (webmars.token/webmars.username) + AuthModal (tabs, busy, 401/409/429/network msg map) + toolbar Sign-in/username/Log-out | FEATURE | A07 | IMPLEMENTED | #47 | AuthModal.tsx; live prod round-trip in A-07
   REQ-002-EXT-1 | (Q2 of REQ-002) | Mobile drawer theme list gains the System option (second theme-picker instance) | FIX | A07 | IMPLEMENTED | #47 | MobileShell.tsx theme section
-  REQ-022 | p.36 §6.5; p.23 D5 | Save-to-Account + ShareModal: create-vs-update semantics, copy link + toast, visibility shown + toggle → PUT | FEATURE | A08 | ⬜ | |
+  REQ-022 | p.36 §6.5; p.23 D5 | Save-to-Account + ShareModal: create-vs-update semantics, copy link + toast, visibility shown + toggle → PUT | FEATURE | A08 | IMPLEMENTED | #48 | SaveSnippetDialog/ShareModal/Toolbar; live save+copy verified; PUT graceful until A12 fix deploys
   REQ-023 | p.44-45 §7.7; p.22-24 D4-D5 | rem pseudo-instruction: lexer mnemonic, parser ["R","R","R"], assembler div+mfhi expansion [live assembler is instructions.ts; PDF-named files also updated] | FEATURE | A05 | IMPLEMENTED | #45 | instructions.ts rem case; pseudoInstructions.test.ts +4 tests
   REQ-024 | p.40 §7.3; p.24 D5 | Snippet entity v1.2: owner FK lazy, Visibility enum STRING, created/updated timestamps + lifecycle hooks | FEATURE | A12 | ⬜ | | pre-exists (verify)
   REQ-025 | p.40-42 §7.4; p.24 D6 | Run entity + RunRepository: findByUserIdOrderByStartedAtDesc + most-run JPQL projection | FEATURE | A12 | ⬜ | | pre-exists (verify)
@@ -983,7 +1027,7 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-035 | p.26-27 D9 | Empty states w/ exact copy: drawer 'Save your first snippet…', history 'Run a saved snippet…', feed 'No public snippets yet. Be the first.' | UI/UX | A11 | ⬜ | |
   REQ-036 | p.27 D9 | Confirm dialogs for deletes: 'Delete <title>? This cannot be undone.' [Cancel][Delete] | UI/UX | A11 | ⬜ | |
   REQ-037 | p.27 D9 | AuthModal/ShareModal/confirm dialogs: focus trap, Escape closes, Enter submits | UI/UX | A11 | ⬜ | |
-  REQ-038 | p.27 D9 | Browser back/forward between /?snippet=N and / restores snippet state (popstate) | FIX | A08 | ⬜ | |
+  REQ-038 | p.27 D9 | Browser back/forward between /?snippet=N and / restores snippet state (popstate) | FIX | A08 | IMPLEMENTED | #48 | popstate handler in App.tsx; clear verified live; restore blocked by upstream 500 (A91 re-verifies post-A12)
   REQ-039 | p.27 D9 | New modals usable below 768px (mobile spot-check) | UI/UX | A11 | ⬜ | |
   REQ-040 | p.27 D9 | Frontend README rewritten for v1.2 surface: features, env vars, run + deploy instructions | DOCS | A11 | ⬜ | |
   REQ-041 | p.27 D9 | Backend README rewritten for v1.2: endpoints, env vars, deployment | DOCS | A12 | ⬜ | | pre-exists upstream (verify)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { Suspense, lazy } from 'react'
-import { Toaster } from 'sonner'
-import { useRoute } from '@/lib/router.ts'
+import { Suspense, lazy, useEffect } from 'react'
+import { Toaster, toast } from 'sonner'
+import { useRoute, getSnippetIdFromUrl } from '@/lib/router.ts'
+import * as api from '@/lib/api.ts'
 import { Shell } from '@/ui/Shell.tsx'
 import { useSimulator, resolveTheme } from '@/hooks/useSimulator.ts'
 import { useSystemColorScheme } from '@/hooks/useSystemColorScheme.ts'
@@ -11,10 +12,55 @@ import { useSystemColorScheme } from '@/hooks/useSystemColorScheme.ts'
 // (and only once — Vite hashes the chunk).
 const LandingPage = lazy(() => import('@/landing/LandingPage.tsx'))
 
+// Enhancement Plan §6.6: visiting /?snippet=<id> loads that snippet
+// into the editor on boot; browser back/forward between /?snippet=N
+// and / restores the association (popstate, plan D9).
+function useSnippetDeepLink(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+
+    function syncFromUrl() {
+      const id = getSnippetIdFromUrl()
+      const s = useSimulator.getState()
+      if (id === null) {
+        // Back on plain / — the editor keeps its content but is no
+        // longer bound to a server snippet.
+        if (s.currentSnippetId !== null) s.setCurrentSnippet(null)
+        return
+      }
+      if (id === s.currentSnippetId) return
+      api
+        .getSnippet(id)
+        .then((snippet) => {
+          if (cancelled) return
+          useSimulator.getState().loadSnippetIntoEditor(snippet)
+          document.title = `${snippet.title ?? `snippet-${snippet.id}`} — WebMARS`
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return
+          if (err instanceof api.ApiError && err.status === 404) {
+            toast.error('That snippet is private or does not exist.')
+          } else {
+            toast.error('Failed to load shared snippet.')
+          }
+        })
+    }
+
+    syncFromUrl()
+    window.addEventListener('popstate', syncFromUrl)
+    return () => {
+      cancelled = true
+      window.removeEventListener('popstate', syncFromUrl)
+    }
+  }, [enabled])
+}
+
 export default function App() {
   const route = useRoute()
   const theme = useSimulator((s) => s.theme)
   const systemScheme = useSystemColorScheme()
+  useSnippetDeepLink(route === 'app')
 
   // Sonner only knows light/dark; the high-contrast shell keeps the
   // dark toast styling.

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { TOKEN_STORAGE_KEY, USERNAME_STORAGE_KEY } from '../lib/api.ts'
+import type { Snippet, Visibility } from '../lib/api.ts'
 import { Simulator } from '../core/simulator.ts'
 import { assemble } from '../core/instructions.ts'
 import { REGISTER_NAMES } from '../core/registers.ts'
@@ -323,6 +324,11 @@ export const WORKSPACE_STORAGE_KEY = 'webmars:workspace-v1'
 export interface PersistedWorkspace {
   files: Array<Pick<FileEntry, 'id' | 'name' | 'source' | 'modified'>>
   activeFileId: string | null
+  // Which server-side snippet the editor was on (Enhancement Plan §6.5)
+  // — lets a refresh remember that Save should UPDATE, not create.
+  currentSnippetId?: number | null
+  currentSnippetTitle?: string | null
+  currentSnippetVisibility?: Visibility | null
 }
 
 export function readPersistedWorkspace(): PersistedWorkspace | null {
@@ -343,7 +349,13 @@ export function readPersistedWorkspace(): PersistedWorkspace | null {
     }
     if (files.length === 0) return null
     const activeFileId = typeof obj.activeFileId === 'string' ? obj.activeFileId : null
-    return { files, activeFileId }
+    const currentSnippetId = typeof obj.currentSnippetId === 'number' ? obj.currentSnippetId : null
+    const currentSnippetTitle = typeof obj.currentSnippetTitle === 'string' ? obj.currentSnippetTitle : null
+    const currentSnippetVisibility =
+      obj.currentSnippetVisibility === 'PUBLIC' || obj.currentSnippetVisibility === 'PRIVATE'
+        ? obj.currentSnippetVisibility
+        : null
+    return { files, activeFileId, currentSnippetId, currentSnippetTitle, currentSnippetVisibility }
   } catch {
     // Corrupt payload or privacy mode — fall back to the default file.
     return null
@@ -756,6 +768,21 @@ interface SimulatorStoreState {
   clearAuth: () => void
   openAuthModal: () => void
   closeAuthModal: () => void
+
+  // ─ snippet slice (Enhancement Plan §6.5/§6.6) ─
+  // Which server-side snippet the editor is on. Persisted with the
+  // workspace so a refresh remembers; null = unsaved local work.
+  currentSnippetId: number | null
+  currentSnippetTitle: string | null
+  currentSnippetVisibility: Visibility | null
+  saveSnippetDialogOpen: boolean
+  shareModalOpen: boolean
+  setCurrentSnippet: (snippet: { id: number; title: string | null; visibility: Visibility } | null) => void
+  loadSnippetIntoEditor: (snippet: Snippet) => void
+  openSaveSnippetDialog: () => void
+  closeSaveSnippetDialog: () => void
+  openShareModal: () => void
+  closeShareModal: () => void
 
   // ─ layoutSizes slice (Phase 3 SA-5; persisted to webmars:layout-sizes) ─
   // Drag-handle sizes for the three resizable Shell regions. The
@@ -1373,6 +1400,59 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
     openAuthModal:  () => set({ authModalOpen: true  }),
     closeAuthModal: () => set({ authModalOpen: false }),
 
+    // snippet slice — currentSnippet* rides the persisted workspace
+    // payload (see the workspace subscription at module bottom).
+    currentSnippetId: persistedWorkspace?.currentSnippetId ?? null,
+    currentSnippetTitle: persistedWorkspace?.currentSnippetTitle ?? null,
+    currentSnippetVisibility: persistedWorkspace?.currentSnippetVisibility ?? null,
+    saveSnippetDialogOpen: false,
+    shareModalOpen: false,
+    setCurrentSnippet: (snippet) =>
+      set({
+        currentSnippetId: snippet?.id ?? null,
+        currentSnippetTitle: snippet?.title ?? null,
+        currentSnippetVisibility: snippet?.visibility ?? null,
+      }),
+    loadSnippetIntoEditor: (snippet) => {
+      const s = get()
+      const fileName = `${snippet.title ?? `snippet-${snippet.id}`}.asm`
+      const existing = s.files.find((f) => f.name === fileName)
+      const meta = {
+        currentSnippetId: snippet.id,
+        currentSnippetTitle: snippet.title,
+        currentSnippetVisibility: snippet.visibility,
+      }
+      if (existing) {
+        set({
+          files: s.files.map((f) =>
+            f.id === existing.id ? { ...f, source: snippet.code, modified: false } : f,
+          ),
+          activeFileId: existing.id,
+          source: snippet.code,
+          ...meta,
+        })
+        return
+      }
+      const id = makeFileId()
+      const entry: FileEntry = {
+        id,
+        name: fileName,
+        source: snippet.code,
+        handle: null,
+        modified: false,
+      }
+      set({
+        files: [...s.files, entry],
+        activeFileId: id,
+        source: snippet.code,
+        ...meta,
+      })
+    },
+    openSaveSnippetDialog:  () => set({ saveSnippetDialogOpen: true  }),
+    closeSaveSnippetDialog: () => set({ saveSnippetDialogOpen: false }),
+    openShareModal:  () => set({ shareModalOpen: true  }),
+    closeShareModal: () => set({ shareModalOpen: false }),
+
     layoutSizes: readPersistedLayoutSizes(),
     setLayoutSize: (key, value) => {
       const next = { ...get().layoutSizes, [key]: value }
@@ -1914,11 +1994,20 @@ function flushWorkspaceWrite(): void {
   writePersistedWorkspace({
     files: s.files.map(({ id, name, source, modified }) => ({ id, name, source, modified })),
     activeFileId: s.activeFileId,
+    currentSnippetId: s.currentSnippetId,
+    currentSnippetTitle: s.currentSnippetTitle,
+    currentSnippetVisibility: s.currentSnippetVisibility,
   })
 }
 
 useSimulator.subscribe((state, prev) => {
-  if (state.files === prev.files && state.activeFileId === prev.activeFileId) return
+  if (
+    state.files === prev.files &&
+    state.activeFileId === prev.activeFileId &&
+    state.currentSnippetId === prev.currentSnippetId &&
+    state.currentSnippetTitle === prev.currentSnippetTitle &&
+    state.currentSnippetVisibility === prev.currentSnippetVisibility
+  ) return
   if (_workspaceWriteTimer !== null) clearTimeout(_workspaceWriteTimer)
   _workspaceWriteTimer = setTimeout(flushWorkspaceWrite, WORKSPACE_WRITE_DEBOUNCE_MS)
 })

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -32,3 +32,24 @@ export function useRoute(): Route {
   }, [])
   return route
 }
+
+// ─ shared-snippet deep links (Enhancement Plan §6.6) ─
+// webmarsimulator.com/?snippet=42 loads snippet 42 on boot; App.tsx
+// owns the fetch + popstate wiring, these helpers own the URL shape.
+
+export function getSnippetIdFromUrl(): number | null {
+  if (typeof window === 'undefined') return null
+  const params = new URLSearchParams(window.location.search)
+  const raw = params.get('snippet')
+  if (!raw) return null
+  const id = parseInt(raw, 10)
+  return Number.isFinite(id) && id > 0 ? id : null
+}
+
+export function setSnippetIdInUrl(id: number | null): void {
+  if (typeof window === 'undefined') return
+  const url = new URL(window.location.href)
+  if (id === null) url.searchParams.delete('snippet')
+  else url.searchParams.set('snippet', String(id))
+  window.history.replaceState({}, '', url.toString())
+}

--- a/src/tests/persist.test.ts
+++ b/src/tests/persist.test.ts
@@ -87,7 +87,13 @@ describe('workspace persistence', () => {
 
     const raw = localStorage.getItem(mod.WORKSPACE_STORAGE_KEY)!
     const payload = JSON.parse(raw) as Record<string, unknown>
-    expect(Object.keys(payload).sort()).toEqual(['activeFileId', 'files'])
+    expect(Object.keys(payload).sort()).toEqual([
+      'activeFileId',
+      'currentSnippetId',
+      'currentSnippetTitle',
+      'currentSnippetVisibility',
+      'files',
+    ])
     expect(raw).not.toContain('registers')
     expect(raw).not.toContain('consoleOutput')
     expect(raw).not.toContain('programCounter')

--- a/src/ui/SaveSnippetDialog.tsx
+++ b/src/ui/SaveSnippetDialog.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import * as api from '@/lib/api.ts'
+import { setSnippetIdInUrl } from '@/lib/router.ts'
+import { useSimulator } from '@/hooks/useSimulator.ts'
+import { cn } from './cn.ts'
+
+// Enhancement Plan §6.5 — first save of a snippet: pick a title and
+// visibility (defaults PRIVATE), POST /snippets/save, then hand off to
+// the ShareModal. Subsequent saves go straight to PUT via the toolbar
+// button and never see this dialog.
+
+export function SaveSnippetDialog() {
+  const open = useSimulator((s) => s.saveSnippetDialogOpen)
+  // The form mounts fresh on every open, so its state (title prefill,
+  // visibility default) initializes at mount — no sync-in-effect.
+  if (!open) return null
+  return <SaveSnippetForm />
+}
+
+function initialTitle(): string {
+  const s = useSimulator.getState()
+  const active = s.files.find((f) => f.id === s.activeFileId)
+  return active ? active.name.replace(/\.(asm|s|mips)$/i, '') : ''
+}
+
+function SaveSnippetForm() {
+  const close = useSimulator((s) => s.closeSaveSnippetDialog)
+
+  const [title, setTitle] = useState(initialTitle)
+  const [visibility, setVisibility] = useState<api.Visibility>('PRIVATE')
+  const [busy, setBusy] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const titleRef = useRef<HTMLInputElement>(null)
+
+  // Keyboard contract: Escape closes, Tab trapped, Enter submits (form).
+  useEffect(() => {
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        close()
+        return
+      }
+      if (event.key === 'Tab' && dialogRef.current) {
+        const focusables = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button, input, [tabindex]:not([tabindex="-1"])',
+        )
+        if (focusables.length === 0) return
+        const first = focusables[0]!
+        const last = focusables[focusables.length - 1]!
+        const active = document.activeElement
+        if (event.shiftKey && (active === first || !dialogRef.current.contains(active))) {
+          event.preventDefault()
+          last.focus()
+        } else if (!event.shiftKey && active === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    titleRef.current?.focus()
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [close])
+
+  async function submit() {
+    if (busy) return
+    const trimmed = title.trim()
+    if (trimmed.length === 0) {
+      toast.error('Give the snippet a title.')
+      return
+    }
+    setBusy(true)
+    try {
+      const s = useSimulator.getState()
+      const snippet = await api.saveSnippet({ title: trimmed, code: s.source, visibility })
+      s.setCurrentSnippet({ id: snippet.id, title: snippet.title, visibility: snippet.visibility })
+      setSnippetIdInUrl(snippet.id)
+      toast.success(`Saved as ${snippet.title ?? trimmed}`)
+      close()
+      useSimulator.getState().openShareModal()
+    } catch (err) {
+      toast.error(
+        err instanceof api.ApiError
+          ? err.status === 401
+            ? 'Your session expired. Sign in again to save.'
+            : `Save failed (HTTP ${err.status}). Please try again.`
+          : 'Save failed. Check your connection.',
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) close()
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Save snippet to account"
+        className="w-full max-w-sm overflow-hidden rounded-lg border border-divider bg-surface-1 shadow-xl"
+      >
+        <header className="border-b border-divider px-5 py-3 text-xs font-medium text-ink-1">
+          Save to account
+        </header>
+        <form
+          className="flex flex-col gap-3 px-5 py-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void submit()
+          }}
+        >
+          <label className="flex flex-col gap-1">
+            <span className="font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+              Title
+            </span>
+            <input
+              ref={titleRef}
+              type="text"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              maxLength={255}
+              disabled={busy}
+              className="rounded-sm border border-divider bg-surface-0 px-2 py-1.5 text-xs text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            />
+          </label>
+
+          <fieldset className="flex flex-col gap-1">
+            <legend className="mb-1 font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+              Visibility
+            </legend>
+            {(
+              [
+                { value: 'PRIVATE', label: 'Private', sub: 'Only you can open it.' },
+                { value: 'PUBLIC', label: 'Public', sub: 'Anyone with the link (and the public feed) can view it.' },
+              ] as const
+            ).map((option) => (
+              <label
+                key={option.value}
+                className={cn(
+                  'flex cursor-pointer items-start gap-2 rounded-sm border px-2 py-1.5 transition-colors',
+                  visibility === option.value ? 'border-accent bg-surface-2' : 'border-divider hover:bg-surface-2',
+                )}
+              >
+                <input
+                  type="radio"
+                  name="visibility"
+                  value={option.value}
+                  checked={visibility === option.value}
+                  onChange={() => setVisibility(option.value)}
+                  disabled={busy}
+                  className="mt-0.5 size-3.5 flex-none accent-accent"
+                />
+                <span className="flex-1">
+                  <span className="block text-xs text-ink-1">{option.label}</span>
+                  <span className="mt-0.5 block text-[11px] text-ink-3">{option.sub}</span>
+                </span>
+              </label>
+            ))}
+          </fieldset>
+
+          <div className="mt-1 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={close}
+              disabled={busy}
+              className="rounded-sm px-3 py-1.5 text-xs text-ink-2 transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy}
+              className={cn(
+                'rounded-sm bg-accent px-3 py-1.5 text-xs font-medium text-surface-0 transition-opacity',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1',
+                busy && 'cursor-not-allowed opacity-60',
+              )}
+            >
+              {busy ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/ShareModal.tsx
+++ b/src/ui/ShareModal.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import * as api from '@/lib/api.ts'
+import { useSimulator } from '@/hooks/useSimulator.ts'
+import { cn } from './cn.ts'
+
+// Enhancement Plan §6.5 — after the first save, show the shareable URL
+// with a copy button, the snippet's visibility, and a toggle to change
+// it (PUT /snippets/{id}).
+
+export function ShareModal() {
+  const open = useSimulator((s) => s.shareModalOpen)
+  const close = useSimulator((s) => s.closeShareModal)
+  const snippetId = useSimulator((s) => s.currentSnippetId)
+  const visibility = useSimulator((s) => s.currentSnippetVisibility)
+  const title = useSimulator((s) => s.currentSnippetTitle)
+
+  const [busy, setBusy] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const copyRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        close()
+        return
+      }
+      if (event.key === 'Tab' && dialogRef.current) {
+        const focusables = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button, input, [tabindex]:not([tabindex="-1"])',
+        )
+        if (focusables.length === 0) return
+        const first = focusables[0]!
+        const last = focusables[focusables.length - 1]!
+        const active = document.activeElement
+        if (event.shiftKey && (active === first || !dialogRef.current.contains(active))) {
+          event.preventDefault()
+          last.focus()
+        } else if (!event.shiftKey && active === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    copyRef.current?.focus()
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [open, close])
+
+  if (!open || snippetId === null) return null
+
+  const shareUrl = `${window.location.origin}/?snippet=${snippetId}`
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      toast.success('Copied to clipboard')
+    } catch {
+      toast.error('Could not access the clipboard — copy the link manually.')
+    }
+  }
+
+  async function toggleVisibility() {
+    if (busy || snippetId === null) return
+    const next: api.Visibility = visibility === 'PUBLIC' ? 'PRIVATE' : 'PUBLIC'
+    setBusy(true)
+    try {
+      const updated = await api.updateSnippet(snippetId, { visibility: next })
+      useSimulator.getState().setCurrentSnippet({
+        id: updated.id,
+        title: updated.title,
+        visibility: updated.visibility,
+      })
+      toast.success(`Snippet is now ${updated.visibility.toLowerCase()}.`)
+    } catch (err) {
+      // PUT /snippets/{id} may not be deployed yet (it ships with the
+      // backend gap PR) — fail with an explanation, never silently.
+      toast.error(
+        err instanceof api.ApiError
+          ? `Could not change visibility (HTTP ${err.status}). The update endpoint may not be live yet.`
+          : 'Could not change visibility. Check your connection.',
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) close()
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Share snippet"
+        className="w-full max-w-md overflow-hidden rounded-lg border border-divider bg-surface-1 shadow-xl"
+      >
+        <header className="border-b border-divider px-5 py-3 text-xs font-medium text-ink-1">
+          Share {title ? `“${title}”` : 'snippet'}
+        </header>
+
+        <div className="flex flex-col gap-3 px-5 py-4">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              readOnly
+              value={shareUrl}
+              onFocus={(event) => event.target.select()}
+              aria-label="Shareable link"
+              className="flex-1 rounded-sm border border-divider bg-surface-0 px-2 py-1.5 font-mono text-[11px] text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            />
+            <button
+              ref={copyRef}
+              type="button"
+              onClick={() => void copyLink()}
+              className="rounded-sm bg-accent px-3 py-1.5 text-xs font-medium text-surface-0 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+            >
+              Copy
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between rounded-sm border border-divider px-3 py-2">
+            <div>
+              <div className="text-xs text-ink-1">
+                Visibility:{' '}
+                <span className={visibility === 'PUBLIC' ? 'text-ok' : 'text-warn'}>
+                  {visibility === 'PUBLIC' ? 'Public' : 'Private'}
+                </span>
+              </div>
+              <div className="mt-0.5 text-[11px] text-ink-3">
+                {visibility === 'PUBLIC'
+                  ? 'Anyone with the link can open it.'
+                  : 'Only you can open it — the link 404s for everyone else.'}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void toggleVisibility()}
+              disabled={busy}
+              className={cn(
+                'rounded-sm bg-surface-2 px-3 py-1.5 text-xs text-ink-1 transition-colors hover:bg-surface-3',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+                busy && 'cursor-not-allowed opacity-60',
+              )}
+            >
+              {busy ? 'Updating…' : visibility === 'PUBLIC' ? 'Make private' : 'Make public'}
+            </button>
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={close}
+              className="rounded-sm px-3 py-1.5 text-xs text-ink-2 transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/Shell.tsx
+++ b/src/ui/Shell.tsx
@@ -13,6 +13,8 @@ import { StatusBar } from './StatusBar.tsx'
 import { DevPanel } from './DevPanel.tsx'
 import { SettingsDialog } from './SettingsDialog.tsx'
 import { AuthModal } from './AuthModal.tsx'
+import { SaveSnippetDialog } from './SaveSnippetDialog.tsx'
+import { ShareModal } from './ShareModal.tsx'
 import { CommandPalette } from './CommandPalette.tsx'
 import { InstructionCounter } from './InstructionCounter.tsx'
 import { HelpDialog } from './HelpDialog.tsx'
@@ -103,6 +105,8 @@ export function Shell() {
       <>
         <MobileShell />
         <AuthModal />
+        <SaveSnippetDialog />
+        <ShareModal />
         {import.meta.env.DEV && <DevPanel />}
       </>
     )
@@ -165,6 +169,8 @@ export function Shell() {
       {import.meta.env.DEV && <DevPanel />}
       <SettingsDialog />
       <AuthModal />
+      <SaveSnippetDialog />
+      <ShareModal />
       <CommandPalette />
       <InstructionCounter />
       <HelpDialog />

--- a/src/ui/Toolbar.tsx
+++ b/src/ui/Toolbar.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { toast } from 'sonner'
+import * as api from '@/lib/api.ts'
 import { useSimulator, type ExampleName, RUN_SPEED_STOPS } from '@/hooks/useSimulator.ts'
 import { getEditorCursor } from '@/lib/editorCursor.ts'
 import { Button } from './Button.tsx'
@@ -201,6 +203,80 @@ function FileOpButton({
 
 function Divider() {
   return <span aria-hidden="true" className="mx-1 h-6 w-px bg-divider" />
+}
+
+// Enhancement Plan §6.5: Save to Account / Share. Visible only when
+// signed in. First save opens the title+visibility dialog (which hands
+// off to the ShareModal); subsequent saves PUT the current snippet in
+// place with a busy state — clicking twice can't double-submit.
+function SaveShareButtons() {
+  const authToken = useSimulator((s) => s.authToken)
+  const currentSnippetId = useSimulator((s) => s.currentSnippetId)
+  const openShareModal = useSimulator((s) => s.openShareModal)
+  const [saving, setSaving] = useState(false)
+
+  if (!authToken) return null
+
+  async function onSave() {
+    if (saving) return
+    const s = useSimulator.getState()
+    if (s.currentSnippetId === null) {
+      s.openSaveSnippetDialog()
+      return
+    }
+    setSaving(true)
+    try {
+      const updated = await api.updateSnippet(s.currentSnippetId, { code: s.source })
+      useSimulator.getState().setCurrentSnippet({
+        id: updated.id,
+        title: updated.title,
+        visibility: updated.visibility,
+      })
+      toast.success(`Saved ${updated.title ?? 'snippet'}`)
+    } catch (err) {
+      toast.error(
+        err instanceof api.ApiError
+          ? err.status === 401
+            ? 'Your session expired. Sign in again to save.'
+            : `Save failed (HTTP ${err.status}). The update endpoint may not be live yet.`
+          : 'Save failed. Check your connection.',
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => void onSave()}
+        disabled={saving}
+        title={
+          currentSnippetId === null
+            ? 'Save this code to your account'
+            : 'Save changes to the current snippet'
+        }
+        className={cn(
+          'mr-1 rounded-sm bg-surface-2 px-2 py-1 text-xs font-medium text-ink-1 transition-colors hover:bg-surface-3',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+          saving && 'cursor-not-allowed opacity-60',
+        )}
+      >
+        {saving ? 'Saving…' : currentSnippetId === null ? 'Save to Account' : 'Save Snippet'}
+      </button>
+      {currentSnippetId !== null && (
+        <button
+          type="button"
+          onClick={openShareModal}
+          title="Show the shareable link for this snippet"
+          className="mr-1 rounded-sm bg-surface-2 px-2 py-1 text-xs font-medium text-ink-1 transition-colors hover:bg-surface-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Share
+        </button>
+      )}
+    </>
+  )
 }
 
 // Enhancement Plan §6.4: Sign-in affordance. Logged out → a "Sign in"
@@ -443,6 +519,9 @@ export function Toolbar() {
 
       {/* Right side: spacer pushes StatusPill to the far edge. */}
       <span className="flex-1" aria-hidden="true" />
+
+      {/* Enhancement Plan §6.5: save-to-account + share. */}
+      <SaveShareButtons />
 
       {/* Enhancement Plan §6.4: account sign-in / username menu. */}
       <AuthMenu />


### PR DESCRIPTION
## Agent
AGENT 08 - Save, Share and Deep Links (loop position: 9 of 18)

## Requirements delivered
- REQ-022 - SaveSnippetDialog (title + visibility, PRIVATE default), ShareModal (copy link, visibility toggle), toolbar create-vs-update semantics
- REQ-009 - /?snippet=<id> boot loading with 404 toast + default-example fallback
- REQ-038 - popstate sync between /?snippet=N and /

## What changed and why
Enhancement Plan sections 6.5/6.6 and 2.9. Snippet metadata (id/title/visibility) rides the persisted workspace so refresh remembers that Save means UPDATE. The update path degrades gracefully with an explanatory toast until the backend PUT endpoint ships.

## Evidence summary
- LIVE: save 200 -> ShareModal -> copy toast + clipboard round-trip; /?snippet=999999 -> exact plan toast + default example; upstream-500 case -> graceful generic toast, app usable
- Build/typecheck/lint exit 0; tests 138/138 (persist payload test updated to include snippet metadata)

## Out of scope / follow-ups
DISCOVERED PRODUCTION BUG (routed to AGENT 12): GET /snippets/{id} 500s for any existing snippet and GET /snippets/public 500s once it has rows - lazy owner proxy serialized after session close (open-in-view=false). The plan's own SnippetResponse DTO (section 7.5) is the fix.