### PR TITLE
agent-09: my-snippets drawer + paginated public feed

### DIFF
--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -165,7 +165,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   AGENT 06 — Tools: Bitmap Grid Sizes + Screen Magnifier ........ ✅ COMPLETE
   AGENT 07 — Accounts UI: Auth Slice + AuthModal + Toolbar ...... ✅ COMPLETE
   AGENT 08 — Save, Share & Deep Links (?snippet=<id>) ........... ✅ COMPLETE
-  AGENT 09 — My Snippets Drawer + Public Feed ................... ⬜ NOT STARTED
+  AGENT 09 — My Snippets Drawer + Public Feed ................... ✅ COMPLETE
   AGENT 10 — Run History: Logging Hook + HistoryPanel ........... ⬜ NOT STARTED
   AGENT 11 — Polish, A11y, Docs, Tests Completion, v1.3 Issues .. ⬜ NOT STARTED
   AGENT 12 — Backend: Verification + Gap PR from Fork ........... ⬜ NOT STARTED
@@ -258,7 +258,14 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   {id} and the populated public feed return 500 (lazy owner proxy +
   open-in-view=false) — share links/feed are DOWN upstream; fix (plan's
   own SnippetResponse DTO) routed to AGENT 12's fork PR. 138/138 green.
-  PR #48.
+  PR #48 merged, main @ 1b3fa4a.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 09: snippets drawer + public feed (REQ-032/033)
+  done as RightPanel accordion sections; ConfirmDialog component ships
+  (REQ-036 base). Live: empty state + discovery link + error states
+  verified; ready-state proven with route mocks (rows, badges, load,
+  delete round-trip, pagination). ⚠ Upstream DELETE also 500s (same
+  lazy-proxy bug) — A12 scope grows. 138/138 green. PR #49.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -962,7 +969,32 @@ APPENDIX A-08 — Save, Share & Deep Links
   PR # / MAIN COMMIT: PR #48.
 --------------------------------------------------------------------------------
 APPENDIX A-09 — My Snippets + Public Feed
-  STATUS: / DATE: / PER-REQ (032/033): / BUILD+TEST: / PR #:
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  REQ-032: IMPLEMENTED — src/ui/MySnippetsDrawer.tsx in a RightPanel
+    accordion section ('My Snippets'): /snippets/mine list w/ title,
+    updated timestamp, public/private badge; click-to-load (+ URL sync);
+    Rename edit-in-place (Enter/blur commits → PUT, Escape cancels);
+    Delete w/ ConfirmDialog (exact D9 copy); + New Snippet clears the
+    binding; sign-in prompt when logged out; loading/empty/error (named
+    HTTP status + Retry) states. src/ui/ConfirmDialog.tsx NEW (REQ-036
+    component, keyboard contract, focus lands on Cancel).
+  REQ-033: IMPLEMENTED — src/ui/PublicFeed.tsx accordion section:
+    paginated /snippets/public (title/owner/updated, Prev/Next + 'Page X
+    of Y'), click-to-load; 'See public snippets' link in the drawer's
+    empty state expands + scrolls to the feed; exact empty copy 'No
+    public snippets yet. Be the first.'
+  LIVE VERIFICATION: fresh-user empty state exact copy + discovery link
+    expand verified against production; error states verified live
+    (upstream 500 → 'HTTP 500' named + Retry). READY-state rendering
+    verified via playwright route mocks (backend list endpoints 500
+    upstream — A-08 bug): 2 rows w/ correct badges; row click → editor
+    text 'li $t0, 1' + URL ?snippet=11; ConfirmDialog copy verbatim;
+    delete → 204 → toast; feed owner + 'Page 1 of 3' pagination.
+  ⚠ UPSTREAM (adds to A-08 finding, routed to A12): DELETE /snippets/
+    {id} ALSO 500s in production (same lazy-owner proxy in the owner
+    check) — verified via direct API probe (apiDeleteStatus: 500).
+  BUILD+TEST: typecheck 0 / lint 0 / build exit 0 / vitest 138/138.
+  PR # / MAIN COMMIT: PR #49.
 --------------------------------------------------------------------------------
 APPENDIX A-10 — Run History
   STATUS: / DATE: / PER-REQ (030/034): / BUILD+TEST: / PR #:
@@ -1021,8 +1053,8 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-029 | p.47 §8.2; p.21 D2 | data-magnify-region on RegisterTable, MemoryPanel, ConsolePanel, StatusBar, FpuRegisterTable (+small-text panels); Monaco excluded | FEATURE | A06 | IMPLEMENTED | #46 | 8 panels tagged; A-06
   REQ-030 | p.49 §8.3; p.25 D6 | Run-logging hook: fire-and-forget at run end (COMPLETED/ERROR/ABORTED), runStartedAt duration, skip unauth/unsaved, never block simulator | FEATURE | A10 | ⬜ | |
   REQ-031 | p.51-52 §8.5; p.53 §9.2 | Frontend tests: api.test.ts, persist.test.ts, rem assembler tests in existing harness | TEST | A11 | ⬜ | | authored by A02/A03/A05; A11 verifies completeness
-  REQ-032 | p.24-25 D6 | MySnippetsDrawer: /mine list w/ title/updated/visibility badge, click-to-load, edit-in-place title, delete w/ confirm, New Snippet button, currentSnippetId persists | FEATURE | A09 | ⬜ | |
-  REQ-033 | p.25 D7 | Public feed: paginated browser (title/owner/updated, Prev/Next/page) + 'See public snippets' discovery link in drawer empty state | FEATURE | A09 | ⬜ | |
+  REQ-032 | p.24-25 D6 | MySnippetsDrawer: /mine list w/ title/updated/visibility badge, click-to-load, edit-in-place title, delete w/ confirm, New Snippet button, currentSnippetId persists | FEATURE | A09 | IMPLEMENTED | #49 | MySnippetsDrawer.tsx; live+mock evidence in A-09
+  REQ-033 | p.25 D7 | Public feed: paginated browser (title/owner/updated, Prev/Next/page) + 'See public snippets' discovery link in drawer empty state | FEATURE | A09 | IMPLEMENTED | #49 | PublicFeed.tsx; live+mock evidence in A-09
   REQ-034 | p.26 D8 | HistoryPanel tab in right inspector: Recent Runs (color-coded status, duration, timestamp) + Most Run (count, last run); click loads snippet | FEATURE | A10 | ⬜ | |
   REQ-035 | p.26-27 D9 | Empty states w/ exact copy: drawer 'Save your first snippet…', history 'Run a saved snippet…', feed 'No public snippets yet. Be the first.' | UI/UX | A11 | ⬜ | |
   REQ-036 | p.27 D9 | Confirm dialogs for deletes: 'Delete <title>? This cannot be undone.' [Cancel][Delete] | UI/UX | A11 | ⬜ | |

--- a/src/ui/ConfirmDialog.tsx
+++ b/src/ui/ConfirmDialog.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from 'react'
+import { cn } from './cn.ts'
+
+// Reusable destructive-action confirm (Enhancement Plan D9):
+// "<message>" [Cancel] [<confirmLabel>]. Escape cancels, Tab is
+// trapped, initial focus lands on Cancel (the safe default), Enter
+// activates the focused button.
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel,
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  open: boolean
+  title: string
+  message: string
+  confirmLabel: string
+  busy?: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        onCancel()
+        return
+      }
+      if (event.key === 'Tab' && dialogRef.current) {
+        const focusables = dialogRef.current.querySelectorAll<HTMLElement>('button')
+        if (focusables.length === 0) return
+        const first = focusables[0]!
+        const last = focusables[focusables.length - 1]!
+        const active = document.activeElement
+        if (event.shiftKey && (active === first || !dialogRef.current.contains(active))) {
+          event.preventDefault()
+          last.focus()
+        } else if (!event.shiftKey && active === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    cancelRef.current?.focus()
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onCancel()
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-label={title}
+        className="w-full max-w-xs overflow-hidden rounded-lg border border-divider bg-surface-1 shadow-xl"
+      >
+        <div className="px-5 py-4">
+          <div className="text-xs font-medium text-ink-1">{title}</div>
+          <div className="mt-1.5 text-[11px] leading-relaxed text-ink-2">{message}</div>
+        </div>
+        <div className="flex items-center justify-end gap-2 border-t border-divider px-5 py-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="rounded-sm px-3 py-1.5 text-xs text-ink-2 transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            className={cn(
+              'rounded-sm bg-danger px-3 py-1.5 text-xs font-medium text-surface-0 transition-opacity hover:opacity-90',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger focus-visible:ring-offset-1',
+              busy && 'cursor-not-allowed opacity-60',
+            )}
+          >
+            {busy ? 'Working…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/MySnippetsDrawer.tsx
+++ b/src/ui/MySnippetsDrawer.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import * as api from '@/lib/api.ts'
+import { setSnippetIdInUrl } from '@/lib/router.ts'
+import { useSimulator } from '@/hooks/useSimulator.ts'
+import { ConfirmDialog } from './ConfirmDialog.tsx'
+import { cn } from './cn.ts'
+
+// Enhancement Plan D6 — the user's saved snippets: title, last-updated,
+// visibility badge; click loads into the editor; edit-in-place title;
+// delete with confirm; New Snippet clears the binding so Save creates
+// a fresh row. Renders inside the RightPanel accordion.
+
+type LoadState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; snippets: api.Snippet[] }
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' })
+}
+
+export function MySnippetsDrawer() {
+  const authToken = useSimulator((s) => s.authToken)
+  const openAuthModal = useSimulator((s) => s.openAuthModal)
+  const currentSnippetId = useSimulator((s) => s.currentSnippetId)
+  const [state, setState] = useState<LoadState>({ kind: 'loading' })
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editingTitle, setEditingTitle] = useState('')
+  const [pendingDelete, setPendingDelete] = useState<api.Snippet | null>(null)
+  const [deleteBusy, setDeleteBusy] = useState(false)
+
+  // Event handlers flip to 'loading' themselves before bumping the key
+  // — the effect only ever sets state from async callbacks.
+  function refresh() {
+    setState({ kind: 'loading' })
+    setRefreshKey((k) => k + 1)
+  }
+
+  useEffect(() => {
+    if (!authToken) return
+    let cancelled = false
+    api
+      .getMySnippets(0, 100)
+      .then((page) => {
+        if (!cancelled) setState({ kind: 'ready', snippets: page.content })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setState({
+          kind: 'error',
+          message:
+            err instanceof api.ApiError
+              ? `The server could not list your snippets (HTTP ${err.status}).`
+              : 'Could not reach the server. Check your connection.',
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [authToken, refreshKey])
+
+  function loadSnippet(snippet: api.Snippet) {
+    useSimulator.getState().loadSnippetIntoEditor(snippet)
+    setSnippetIdInUrl(snippet.id)
+    toast.success(`Loaded ${snippet.title ?? `snippet-${snippet.id}`}`)
+  }
+
+  async function commitTitle(snippet: api.Snippet) {
+    const next = editingTitle.trim()
+    setEditingId(null)
+    if (next.length === 0 || next === snippet.title) return
+    try {
+      await api.updateSnippet(snippet.id, { title: next })
+      toast.success('Title updated')
+      refresh()
+    } catch (err) {
+      toast.error(
+        err instanceof api.ApiError
+          ? `Rename failed (HTTP ${err.status}). The update endpoint may not be live yet.`
+          : 'Rename failed. Check your connection.',
+      )
+    }
+  }
+
+  async function confirmDelete() {
+    if (!pendingDelete || deleteBusy) return
+    setDeleteBusy(true)
+    try {
+      await api.deleteSnippet(pendingDelete.id)
+      toast.success(`Deleted ${pendingDelete.title ?? 'snippet'}`)
+      if (useSimulator.getState().currentSnippetId === pendingDelete.id) {
+        useSimulator.getState().setCurrentSnippet(null)
+        setSnippetIdInUrl(null)
+      }
+      setPendingDelete(null)
+      refresh()
+    } catch (err) {
+      toast.error(
+        err instanceof api.ApiError
+          ? `Delete failed (HTTP ${err.status}).`
+          : 'Delete failed. Check your connection.',
+      )
+    } finally {
+      setDeleteBusy(false)
+    }
+  }
+
+  function newSnippet() {
+    const s = useSimulator.getState()
+    s.newFile()
+    s.setCurrentSnippet(null)
+    setSnippetIdInUrl(null)
+  }
+
+  if (!authToken) {
+    return (
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+        <span>Sign in to save snippets to your account. </span>
+        <button
+          type="button"
+          onClick={openAuthModal}
+          className="text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Sign in
+        </button>
+      </div>
+    )
+  }
+
+  if (state.kind === 'loading' || state.kind === 'idle') {
+    return <div className="p-3 text-xs italic text-ink-3">Loading your snippets…</div>
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+        <div className="text-danger">{state.message}</div>
+        <button
+          type="button"
+          onClick={refresh}
+          className="mt-2 rounded-sm bg-surface-3 px-2 py-1 text-xs text-ink-1 transition-colors hover:bg-surface-3/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={newSnippet}
+        className="self-start rounded-sm bg-surface-2 px-2 py-1 text-xs text-ink-1 transition-colors hover:bg-surface-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        + New Snippet
+      </button>
+
+      {state.snippets.length === 0 ? (
+        <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+          <div>Save your first snippet to see it here.</div>
+          <button
+            type="button"
+            onClick={() => {
+              // Expand + reveal the Public Snippets accordion below.
+              const header = document.getElementById('right-panel-public-snippets-header')
+              if (header?.getAttribute('aria-expanded') === 'false') header.click()
+              header?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            }}
+            className="mt-1.5 text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            See public snippets
+          </button>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {state.snippets.map((snippet) => (
+            <li
+              key={snippet.id}
+              className={cn(
+                'group rounded-sm border px-2 py-1.5',
+                snippet.id === currentSnippetId ? 'border-accent bg-surface-2' : 'border-divider hover:bg-surface-2',
+              )}
+            >
+              <div className="flex items-center gap-2">
+                {editingId === snippet.id ? (
+                  <input
+                    type="text"
+                    value={editingTitle}
+                    autoFocus
+                    maxLength={255}
+                    onChange={(event) => setEditingTitle(event.target.value)}
+                    onBlur={() => void commitTitle(snippet)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') void commitTitle(snippet)
+                      if (event.key === 'Escape') setEditingId(null)
+                    }}
+                    aria-label="Snippet title"
+                    className="min-w-0 flex-1 rounded-sm border border-divider bg-surface-0 px-1.5 py-0.5 text-xs text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => loadSnippet(snippet)}
+                    title="Load into the editor"
+                    className="min-w-0 flex-1 truncate text-left text-xs text-ink-1 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  >
+                    {snippet.title ?? `snippet-${snippet.id}`}
+                  </button>
+                )}
+                <span
+                  className={cn(
+                    'flex-none rounded-pill px-1.5 py-0.5 font-mono text-[9px] uppercase',
+                    snippet.visibility === 'PUBLIC' ? 'bg-ok/15 text-ok' : 'bg-surface-3 text-ink-3',
+                  )}
+                  style={{ letterSpacing: '0.05em' }}
+                >
+                  {snippet.visibility === 'PUBLIC' ? 'public' : 'private'}
+                </span>
+              </div>
+              <div className="mt-0.5 flex items-center gap-2">
+                <span className="font-mono text-[10px] text-ink-3">{formatWhen(snippet.updatedAt)}</span>
+                <span className="flex-1" />
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingId(snippet.id)
+                    setEditingTitle(snippet.title ?? '')
+                  }}
+                  className="text-[10px] text-ink-3 hover:text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  Rename
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPendingDelete(snippet)}
+                  className="text-[10px] text-ink-3 hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete snippet"
+        message={`Delete ${pendingDelete?.title ?? 'this snippet'}? This cannot be undone.`}
+        confirmLabel="Delete"
+        busy={deleteBusy}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={() => void confirmDelete()}
+      />
+    </div>
+  )
+}

--- a/src/ui/PublicFeed.tsx
+++ b/src/ui/PublicFeed.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import * as api from '@/lib/api.ts'
+import { setSnippetIdInUrl } from '@/lib/router.ts'
+import { useSimulator } from '@/hooks/useSimulator.ts'
+
+// Enhancement Plan D7 — browse public snippets: title, owner username,
+// last-updated, click-to-load, Previous/Next pagination. Renders inside
+// the RightPanel accordion; anonymous users can browse and load.
+
+const PAGE_SIZE = 20
+
+type FeedState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; page: api.Page<api.Snippet> }
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleDateString(undefined, { dateStyle: 'short' })
+}
+
+export function PublicFeed() {
+  const [pageIndex, setPageIndex] = useState(0)
+  const [state, setState] = useState<FeedState>({ kind: 'loading' })
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  // Event handlers flip to 'loading' themselves — the effect only sets
+  // state from async callbacks.
+  function refresh() {
+    setState({ kind: 'loading' })
+    setRefreshKey((k) => k + 1)
+  }
+
+  function goToPage(next: number) {
+    setState({ kind: 'loading' })
+    setPageIndex(next)
+  }
+
+  useEffect(() => {
+    let cancelled = false
+    api
+      .getPublicSnippets(pageIndex, PAGE_SIZE)
+      .then((page) => {
+        if (!cancelled) setState({ kind: 'ready', page })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setState({
+          kind: 'error',
+          message:
+            err instanceof api.ApiError
+              ? `The server could not list public snippets (HTTP ${err.status}).`
+              : 'Could not reach the server. Check your connection.',
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [pageIndex, refreshKey])
+
+  function loadSnippet(snippet: api.Snippet) {
+    useSimulator.getState().loadSnippetIntoEditor(snippet)
+    setSnippetIdInUrl(snippet.id)
+    toast.success(`Loaded ${snippet.title ?? `snippet-${snippet.id}`}`)
+  }
+
+  if (state.kind === 'loading') {
+    return <div className="p-3 text-xs italic text-ink-3">Loading public snippets…</div>
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+        <div className="text-danger">{state.message}</div>
+        <button
+          type="button"
+          onClick={refresh}
+          className="mt-2 rounded-sm bg-surface-3 px-2 py-1 text-xs text-ink-1 transition-colors hover:bg-surface-3/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  const { page } = state
+
+  return (
+    <div className="flex flex-col gap-2">
+      {page.content.length === 0 ? (
+        <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+          No public snippets yet. Be the first.
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {page.content.map((snippet) => (
+            <li key={snippet.id} className="rounded-sm border border-divider px-2 py-1.5 hover:bg-surface-2">
+              <button
+                type="button"
+                onClick={() => loadSnippet(snippet)}
+                title="Load into the editor"
+                className="block w-full truncate text-left text-xs text-ink-1 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                {snippet.title ?? `snippet-${snippet.id}`}
+              </button>
+              <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-ink-3">
+                <span>{snippet.owner?.username ?? 'unknown'}</span>
+                <span className="flex-1" />
+                <span>{formatWhen(snippet.updatedAt)}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(page.totalPages ?? 0) > 1 && (
+        <nav aria-label="Public snippets pages" className="flex items-center justify-between">
+          <button
+            type="button"
+            disabled={page.first}
+            onClick={() => goToPage(Math.max(0, pageIndex - 1))}
+            className="rounded-sm bg-surface-2 px-2 py-1 text-xs text-ink-1 transition-colors hover:bg-surface-3 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            ← Previous
+          </button>
+          <span className="font-mono text-[10px] text-ink-3">
+            Page {page.number + 1} of {page.totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page.last}
+            onClick={() => goToPage(pageIndex + 1)}
+            className="rounded-sm bg-surface-2 px-2 py-1 text-xs text-ink-1 transition-colors hover:bg-surface-3 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            Next →
+          </button>
+        </nav>
+      )}
+    </div>
+  )
+}

--- a/src/ui/RightPanel.tsx
+++ b/src/ui/RightPanel.tsx
@@ -4,6 +4,8 @@ import { cn } from './cn.ts'
 import { RegisterTable } from './RegisterTable.tsx'
 import { FpuRegisterTable } from './FpuRegisterTable.tsx'
 import { MemoryPanel } from './MemoryPanel.tsx'
+import { MySnippetsDrawer } from './MySnippetsDrawer.tsx'
+import { PublicFeed } from './PublicFeed.tsx'
 
 interface AccordionSectionProps {
   title: string
@@ -100,6 +102,14 @@ export function RightPanel() {
 
       <AccordionSection title="Memory" defaultOpen={false}>
         <MemoryPanel />
+      </AccordionSection>
+
+      <AccordionSection title="My Snippets" defaultOpen={false}>
+        <MySnippetsDrawer />
+      </AccordionSection>
+
+      <AccordionSection title="Public Snippets" defaultOpen={false}>
+        <PublicFeed />
       </AccordionSection>
 
       <AccordionSection title="Watches" futureSubAgent="SA-11">


### PR DESCRIPTION
## Agent
AGENT 09 - My Snippets Drawer + Public Feed (loop position: 10 of 18)

## Requirements delivered
- REQ-032 - MySnippetsDrawer (list, badges, click-to-load, rename-in-place, delete-with-confirm, New Snippet) as a RightPanel accordion section
- REQ-033 - PublicFeed (paginated, owner/updated, Prev/Next) + 'See public snippets' discovery link
- ConfirmDialog component (REQ-036 base) with the plan's exact copy and keyboard contract

## What changed and why
Enhancement Plan Days 6-7. Both surfaces follow the RightPanel accordion convention and ship full loading/empty/error states; errors name the HTTP status and offer Retry (the production list endpoints currently 500 - see follow-ups).

## Evidence summary
- Live: fresh-user empty state exact copy, discovery link expands the feed, error states render with status + Retry
- Mocked-network proof of ready states: rows + badges, click loads code into the editor and sets ?snippet=11, confirm-dialog copy verbatim, delete 204 round-trip, 'Page 1 of 3' pagination
- Build/typecheck/lint exit 0; tests 138/138

## Out of scope / follow-ups
Upstream DELETE /snippets/{id} also 500s in production (same lazy-owner serialization bug family) - added to AGENT 12's fork-PR scope.