### PR TITLE
agent-10: run logging hook + history panel

### DIFF
--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -166,7 +166,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   AGENT 07 — Accounts UI: Auth Slice + AuthModal + Toolbar ...... ✅ COMPLETE
   AGENT 08 — Save, Share & Deep Links (?snippet=<id>) ........... ✅ COMPLETE
   AGENT 09 — My Snippets Drawer + Public Feed ................... ✅ COMPLETE
-  AGENT 10 — Run History: Logging Hook + HistoryPanel ........... ⬜ NOT STARTED
+  AGENT 10 — Run History: Logging Hook + HistoryPanel ........... ✅ COMPLETE
   AGENT 11 — Polish, A11y, Docs, Tests Completion, v1.3 Issues .. ⬜ NOT STARTED
   AGENT 12 — Backend: Verification + Gap PR from Fork ........... ⬜ NOT STARTED
   ──────────────────────────────────────────────────────────────────────────────
@@ -265,7 +265,16 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   (REQ-036 base). Live: empty state + discovery link + error states
   verified; ready-state proven with route mocks (rows, badges, load,
   delete round-trip, pagination). ⚠ Upstream DELETE also 500s (same
-  lazy-proxy bug) — A12 scope grows. 138/138 green. PR #49.
+  lazy-proxy bug) — A12 scope grows. 138/138 green. PR #49 merged, main
+  @ 7c5b706.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 10: run history (REQ-030/034) done. Fire-and-forget
+  logging wired to all run-end paths (COMPLETED/ERROR/ABORTED-on-reset);
+  HistoryPanel accordion w/ per-section states. LIVE: anonymous runs
+  never POST; authed run POSTs; Most Run shows real production data;
+  Recent Runs isolates its upstream-500 error with Retry. Upstream bug
+  matrix completed: POST /runs private→500 public→200; recent→500 w/
+  rows; most-run→200. 138/138 green. PR #50.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -997,7 +1006,33 @@ APPENDIX A-09 — My Snippets + Public Feed
   PR # / MAIN COMMIT: PR #49.
 --------------------------------------------------------------------------------
 APPENDIX A-10 — Run History
-  STATUS: / DATE: / PER-REQ (030/034): / BUILD+TEST: / PR #:
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  REQ-030: IMPLEMENTED — useSimulator.ts: logRunIfPossible fire-and-forget
+    helper (skips when signed out or snippet unsaved; console.warn on
+    failure; never blocks the simulator); _runStartedAt stamped at run()
+    start for durationMs; wired to run() halt → COMPLETED, run()/step()
+    catch → ERROR (with message), step()-to-halt → COMPLETED, reset()
+    while running → ABORTED [interpretation: Reset mid-run is the user
+    abort; Pause is resumable and logs nothing]; runLogVersion bump
+    refreshes an open HistoryPanel after each successful POST.
+    LIVE: anonymous run → ZERO /runs requests + program output intact
+    (never blocked); authed run of a saved snippet → POST /runs fired.
+  REQ-034: IMPLEMENTED — src/ui/HistoryPanel.tsx in a 'Run History'
+    RightPanel accordion: Recent Runs (color-coded status badges
+    ok/danger/warn, duration ms/s, timestamp) + Most Run (×count, last
+    run); click loads the snippet; exact empty copy 'Run a saved snippet
+    to see your history here.'; per-SECTION loading/empty/error states so
+    one failing endpoint can't blank the other's data.
+    LIVE: Most Run renders REAL production data ('qa-a10-public-runlog
+    ×1'); Recent Runs shows its own named error (HTTP 500) + Retry;
+    empty state verified before any runs existed.
+  ⚠ UPSTREAM (adds to the A-08/A-09 finding, routed to A12): POST /runs
+    500s for PRIVATE snippets (visibility check touches the lazy owner
+    proxy) but works for PUBLIC (200, verified: RunResponse id 1); GET
+    /runs/recent 500s once rows exist (RunResponse.from touches the lazy
+    snippet proxy); GET /runs/most-run works (interface projection).
+  BUILD+TEST: typecheck 0 / lint 0 / build exit 0 / vitest 138/138.
+  PR # / MAIN COMMIT: PR #50.
 --------------------------------------------------------------------------------
 APPENDIX A-11 — Polish, A11y, Docs, Tests, Issues
   STATUS: / DATE: / PER-REQ (031/035/036/037/039/040/042/046/047): /
@@ -1051,11 +1086,11 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-027 | p.43-44 §7.6; p.25 D7 | RunController: POST /runs (user from JWT, never from body), GET /runs/recent, GET /runs/most-run, limit caps [+upstream audit C2: add visibility check on POST] | FEATURE | A12 | ⬜ | | pre-exists; C2 fix → fork PR
   REQ-028 | p.46 §8.1; p.20 D1 | BitmapDisplay DIMENSION_OPTIONS gains 8 and 16; existing sizes unaffected | FEATURE | A06 | IMPLEMENTED | #46 | BitmapDisplay.tsx:16; browser-verified option list
   REQ-029 | p.47 §8.2; p.21 D2 | data-magnify-region on RegisterTable, MemoryPanel, ConsolePanel, StatusBar, FpuRegisterTable (+small-text panels); Monaco excluded | FEATURE | A06 | IMPLEMENTED | #46 | 8 panels tagged; A-06
-  REQ-030 | p.49 §8.3; p.25 D6 | Run-logging hook: fire-and-forget at run end (COMPLETED/ERROR/ABORTED), runStartedAt duration, skip unauth/unsaved, never block simulator | FEATURE | A10 | ⬜ | |
+  REQ-030 | p.49 §8.3; p.25 D6 | Run-logging hook: fire-and-forget at run end (COMPLETED/ERROR/ABORTED), runStartedAt duration, skip unauth/unsaved, never block simulator | FEATURE | A10 | IMPLEMENTED | #50 | useSimulator logRunIfPossible; live anonymous-skip + authed-POST evidence in A-10
   REQ-031 | p.51-52 §8.5; p.53 §9.2 | Frontend tests: api.test.ts, persist.test.ts, rem assembler tests in existing harness | TEST | A11 | ⬜ | | authored by A02/A03/A05; A11 verifies completeness
   REQ-032 | p.24-25 D6 | MySnippetsDrawer: /mine list w/ title/updated/visibility badge, click-to-load, edit-in-place title, delete w/ confirm, New Snippet button, currentSnippetId persists | FEATURE | A09 | IMPLEMENTED | #49 | MySnippetsDrawer.tsx; live+mock evidence in A-09
   REQ-033 | p.25 D7 | Public feed: paginated browser (title/owner/updated, Prev/Next/page) + 'See public snippets' discovery link in drawer empty state | FEATURE | A09 | IMPLEMENTED | #49 | PublicFeed.tsx; live+mock evidence in A-09
-  REQ-034 | p.26 D8 | HistoryPanel tab in right inspector: Recent Runs (color-coded status, duration, timestamp) + Most Run (count, last run); click loads snippet | FEATURE | A10 | ⬜ | |
+  REQ-034 | p.26 D8 | HistoryPanel tab in right inspector: Recent Runs (color-coded status, duration, timestamp) + Most Run (count, last run); click loads snippet | FEATURE | A10 | IMPLEMENTED | #50 | HistoryPanel.tsx; live Most-Run real data + per-section states in A-10
   REQ-035 | p.26-27 D9 | Empty states w/ exact copy: drawer 'Save your first snippet…', history 'Run a saved snippet…', feed 'No public snippets yet. Be the first.' | UI/UX | A11 | ⬜ | |
   REQ-036 | p.27 D9 | Confirm dialogs for deletes: 'Delete <title>? This cannot be undone.' [Cancel][Delete] | UI/UX | A11 | ⬜ | |
   REQ-037 | p.27 D9 | AuthModal/ShareModal/confirm dialogs: focus trap, Escape closes, Enter submits | UI/UX | A11 | ⬜ | |

--- a/src/hooks/useSimulator.ts
+++ b/src/hooks/useSimulator.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { TOKEN_STORAGE_KEY, USERNAME_STORAGE_KEY } from '../lib/api.ts'
+import { TOKEN_STORAGE_KEY, USERNAME_STORAGE_KEY, logRun } from '../lib/api.ts'
 import type { Snippet, Visibility } from '../lib/api.ts'
 import { Simulator } from '../core/simulator.ts'
 import { assemble } from '../core/instructions.ts'
@@ -783,6 +783,9 @@ interface SimulatorStoreState {
   closeSaveSnippetDialog: () => void
   openShareModal: () => void
   closeShareModal: () => void
+  // Bumped after each successful POST /runs so an open HistoryPanel
+  // refetches (Enhancement Plan §8.3).
+  runLogVersion: number
 
   // ─ layoutSizes slice (Phase 3 SA-5; persisted to webmars:layout-sizes) ─
   // Drag-handle sizes for the three resizable Shell regions. The
@@ -867,6 +870,41 @@ let _stopFlag = false
 // matches. Cleared on hit, on reset, and when run() exits for any
 // other reason.
 let _tempBreakpoint: number | null = null
+
+// ─ run logging (Enhancement Plan §8.3) ─
+//
+// Fire-and-forget POST /runs when a run ends (completion, error, or
+// user abort). Skips silently when the user isn't signed in or the
+// snippet was never saved (no snippetId to attach). NEVER blocks or
+// breaks the simulator — failures are console.warn only.
+
+let _runStartedAt: number | null = null
+
+function logRunIfPossible(
+  get: () => SimulatorStoreState,
+  exitStatus: 'COMPLETED' | 'ERROR' | 'ABORTED',
+  errorMessage?: string,
+): void {
+  const s = get()
+  const snippetId = s.currentSnippetId
+  if (snippetId === null || !s.authToken) return
+  const durationMs = _runStartedAt !== null ? Date.now() - _runStartedAt : undefined
+  _runStartedAt = null
+  logRun({
+    snippetId,
+    durationMs,
+    instructionsExecuted: s.instructionsExecuted,
+    exitStatus,
+    errorMessage,
+  })
+    .then(() => {
+      // Nudge any open HistoryPanel to refetch.
+      useSimulator.setState((prev) => ({ runLogVersion: prev.runLogVersion + 1 }))
+    })
+    .catch((err: unknown) => {
+      console.warn('Failed to log run:', err)
+    })
+}
 
 // ─ backstep history (commit 3) ─
 //
@@ -1452,6 +1490,7 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
     closeSaveSnippetDialog: () => set({ saveSnippetDialogOpen: false }),
     openShareModal:  () => set({ shareModalOpen: true  }),
     closeShareModal: () => set({ shareModalOpen: false }),
+    runLogVersion: 0,
 
     layoutSizes: readPersistedLayoutSizes(),
     setLayoutSize: (key, value) => {
@@ -1838,6 +1877,8 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
             },
           })
           get().refreshMemorySnapshot()
+          // §8.3: a step that halts the program is a completed run.
+          if (sim.isHalted()) logRunIfPossible(get, 'COMPLETED')
         } catch (e: unknown) {
           _currentMemWrites = null
           const message = e instanceof Error ? e.message : String(e)
@@ -1845,6 +1886,7 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
             status: 'error',
             runtimeError: { pc: get().registers.pc, message },
           })
+          logRunIfPossible(get, 'ERROR', message)
         }
       })()
     },
@@ -1855,6 +1897,7 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
       const sim = makeSim()
       patchMemoryForBackstep(sim)
       _stopFlag = false
+      _runStartedAt = Date.now()
       // SA-1: pre-warm console-buffer set BEFORE the first sim.step
       // so React commits a paint of the always-mounted ConsolePanel
       // before the first print's microtask lands.
@@ -1924,6 +1967,9 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
             },
           })
           get().refreshMemorySnapshot()
+          // §8.3: log completed runs. Breakpoint hits / pauses are not
+          // run ends — the user can resume; nothing is logged for them.
+          if (sim.isHalted()) logRunIfPossible(get, 'COMPLETED')
         } catch (e: unknown) {
           _currentMemWrites = null
           const message = e instanceof Error ? e.message : String(e)
@@ -1931,11 +1977,14 @@ export const useSimulator = create<SimulatorStoreState>((set, get) => {
             status: 'error',
             runtimeError: { pc: get().registers.pc, message },
           })
+          logRunIfPossible(get, 'ERROR', message)
         }
       })()
     },
 
     reset: () => {
+      // §8.3: resetting a RUNNING program is the user-initiated abort.
+      if (get().status === 'running') logRunIfPossible(get, 'ABORTED')
       _stopFlag = true
       _tempBreakpoint = null
       clearHistory()

--- a/src/ui/HistoryPanel.tsx
+++ b/src/ui/HistoryPanel.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import * as api from '@/lib/api.ts'
+import { setSnippetIdInUrl } from '@/lib/router.ts'
+import { useSimulator } from '@/hooks/useSimulator.ts'
+import { cn } from './cn.ts'
+
+// Enhancement Plan D8 — run history in the right inspector: Recent Runs
+// (status badge, duration, timestamp) and Most Run (count, last run).
+// Clicking a row loads that snippet into the editor. Refetches when a
+// run is logged (runLogVersion bump from the §8.3 hook).
+
+// Each half loads independently so one failing endpoint (e.g. the
+// upstream /runs/recent bug) can't blank the other's data.
+type SectionState<T> =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; items: T[] }
+
+function sectionError(err: unknown, what: string): { kind: 'error'; message: string } {
+  return {
+    kind: 'error',
+    message:
+      err instanceof api.ApiError
+        ? `The server could not load ${what} (HTTP ${err.status}).`
+        : `Could not reach the server for ${what}.`,
+  }
+}
+
+const STATUS_BADGE: Record<api.ExitStatus, string> = {
+  COMPLETED: 'bg-ok/15 text-ok',
+  ERROR: 'bg-danger/15 text-danger',
+  ABORTED: 'bg-warn/15 text-warn',
+  PAUSED: 'bg-surface-3 text-ink-3',
+}
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' })
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return ''
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`
+}
+
+function SectionFallback({ state, onRetry }: { state: SectionState<unknown>; onRetry: () => void }) {
+  if (state.kind === 'loading') return <div className="text-[11px] italic text-ink-3">Loading…</div>
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-md border border-divider bg-surface-2 p-2 text-[11px] text-ink-3">
+        <div className="text-danger">{state.message}</div>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-1.5 rounded-sm bg-surface-3 px-2 py-0.5 text-[11px] text-ink-1 transition-colors hover:bg-surface-3/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+  return <div className="text-[11px] italic text-ink-3">No runs yet.</div>
+}
+
+export function HistoryPanel() {
+  const authToken = useSimulator((s) => s.authToken)
+  const openAuthModal = useSimulator((s) => s.openAuthModal)
+  const runLogVersion = useSimulator((s) => s.runLogVersion)
+  const [recent, setRecent] = useState<SectionState<api.Run>>({ kind: 'loading' })
+  const [mostRun, setMostRun] = useState<SectionState<api.MostRun>>({ kind: 'loading' })
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  function refresh() {
+    setRecent({ kind: 'loading' })
+    setMostRun({ kind: 'loading' })
+    setRefreshKey((k) => k + 1)
+  }
+
+  useEffect(() => {
+    if (!authToken) return
+    let cancelled = false
+    api
+      .getRecentRuns(20)
+      .then((items) => {
+        if (!cancelled) setRecent({ kind: 'ready', items })
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setRecent(sectionError(err, 'recent runs'))
+      })
+    api
+      .getMostRunPrograms(10)
+      .then((items) => {
+        if (!cancelled) setMostRun({ kind: 'ready', items })
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setMostRun(sectionError(err, 'most-run programs'))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [authToken, refreshKey, runLogVersion])
+
+  function loadSnippetById(id: number) {
+    api
+      .getSnippet(id)
+      .then((snippet) => {
+        useSimulator.getState().loadSnippetIntoEditor(snippet)
+        setSnippetIdInUrl(snippet.id)
+        toast.success(`Loaded ${snippet.title ?? `snippet-${snippet.id}`}`)
+      })
+      .catch((err: unknown) => {
+        toast.error(
+          err instanceof api.ApiError && err.status === 404
+            ? 'That snippet no longer exists.'
+            : 'Could not load the snippet.',
+        )
+      })
+  }
+
+  if (!authToken) {
+    return (
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+        <span>Sign in to record and see your run history. </span>
+        <button
+          type="button"
+          onClick={openAuthModal}
+          className="text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Sign in
+        </button>
+      </div>
+    )
+  }
+
+  if (recent.kind === 'loading' && mostRun.kind === 'loading') {
+    return <div className="p-3 text-xs italic text-ink-3">Loading run history…</div>
+  }
+
+  if (
+    recent.kind === 'ready' &&
+    mostRun.kind === 'ready' &&
+    recent.items.length === 0 &&
+    mostRun.items.length === 0
+  ) {
+    return (
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+        Run a saved snippet to see your history here.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <section>
+        <h4 className="mb-1.5 font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+          Recent Runs
+        </h4>
+        {recent.kind !== 'ready' || recent.items.length === 0 ? (
+          <SectionFallback state={recent} onRetry={refresh} />
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {recent.items.map((run) => (
+              <li key={run.id} className="rounded-sm border border-divider px-2 py-1.5 hover:bg-surface-2">
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => loadSnippetById(run.snippetId)}
+                    title="Load this snippet into the editor"
+                    className="min-w-0 flex-1 truncate text-left text-xs text-ink-1 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  >
+                    {run.snippetTitle ?? `snippet-${run.snippetId}`}
+                  </button>
+                  <span
+                    className={cn(
+                      'flex-none rounded-pill px-1.5 py-0.5 font-mono text-[9px] uppercase',
+                      STATUS_BADGE[run.exitStatus],
+                    )}
+                    style={{ letterSpacing: '0.05em' }}
+                  >
+                    {run.exitStatus.toLowerCase()}
+                  </span>
+                </div>
+                <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-ink-3">
+                  <span>{formatWhen(run.startedAt)}</span>
+                  <span className="flex-1" />
+                  <span>{formatDuration(run.durationMs)}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h4 className="mb-1.5 font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+          Most Run
+        </h4>
+        {mostRun.kind !== 'ready' || mostRun.items.length === 0 ? (
+          <SectionFallback state={mostRun} onRetry={refresh} />
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {mostRun.items.map((entry) => (
+              <li key={entry.snippetId} className="rounded-sm border border-divider px-2 py-1.5 hover:bg-surface-2">
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => loadSnippetById(entry.snippetId)}
+                    title="Load this snippet into the editor"
+                    className="min-w-0 flex-1 truncate text-left text-xs text-ink-1 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  >
+                    {entry.snippetTitle ?? `snippet-${entry.snippetId}`}
+                  </button>
+                  <span className="flex-none font-mono text-[10px] text-ink-2">
+                    ×{entry.runCount}
+                  </span>
+                </div>
+                <div className="mt-0.5 font-mono text-[10px] text-ink-3">
+                  last run {formatWhen(entry.lastRun)}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/ui/RightPanel.tsx
+++ b/src/ui/RightPanel.tsx
@@ -6,6 +6,7 @@ import { FpuRegisterTable } from './FpuRegisterTable.tsx'
 import { MemoryPanel } from './MemoryPanel.tsx'
 import { MySnippetsDrawer } from './MySnippetsDrawer.tsx'
 import { PublicFeed } from './PublicFeed.tsx'
+import { HistoryPanel } from './HistoryPanel.tsx'
 
 interface AccordionSectionProps {
   title: string
@@ -110,6 +111,10 @@ export function RightPanel() {
 
       <AccordionSection title="Public Snippets" defaultOpen={false}>
         <PublicFeed />
+      </AccordionSection>
+
+      <AccordionSection title="Run History" defaultOpen={false}>
+        <HistoryPanel />
       </AccordionSection>
 
       <AccordionSection title="Watches" futureSubAgent="SA-11">


### PR DESCRIPTION
## Agent
AGENT 10 - Run History (loop position: 11 of 18)

## Requirements delivered
- REQ-030 - fire-and-forget run logging at every run end (COMPLETED / ERROR / ABORTED-on-reset), duration from runStartedAt, skips unauthenticated/unsaved, never blocks the simulator
- REQ-034 - HistoryPanel accordion: Recent Runs (color-coded badges, duration, timestamp) + Most Run (count, last run), click-to-load, per-section loading/empty/error states

## What changed and why
Enhancement Plan sections 8.3 and Day 8. Interpretation: Reset while running is the user abort (Pause is resumable and logs nothing). The panel loads each section independently so the upstream /runs/recent bug cannot blank the working Most Run data.

## Evidence summary
- LIVE: anonymous run -> zero /runs requests + program output intact; authed run of saved snippet -> POST /runs fired; Most Run renders real production data; Recent Runs isolates its HTTP 500 with Retry
- Upstream API matrix (routed to AGENT 12): POST /runs private->500 / public->200; GET recent->500 with rows; GET most-run->200
- Build/typecheck/lint exit 0; tests 138/138