### PR TITLE
agent-90: quality sweep - measured contrast fixes, touch targets, security scan

### DIFF
--- a/docs/WebMARS_Master_Prompt_V1.txt
+++ b/docs/WebMARS_Master_Prompt_V1.txt
@@ -171,7 +171,7 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   AGENT 12 — Backend: Verification + Gap PR from Fork ........... ✅ COMPLETE
   ──────────────────────────────────────────────────────────────────────────────
 
-  AGENT 90 — Cross-Cutting Quality Sweep ........................ ⬜ NOT STARTED
+  AGENT 90 — Cross-Cutting Quality Sweep ........................ ✅ COMPLETE
   AGENT 91 — Gap Closure: PDF vs Reality, Q1/Q2/Q3 .............. ⬜ NOT STARTED
   AGENT 92 — Infrastructure & Config via CLI .................... ⬜ NOT STARTED
   AGENT 93 — AI Tooling Disclosure (single-purpose PR) .......... ⬜ NOT STARTED
@@ -294,7 +294,15 @@ Mark each agent: ⬜ NOT STARTED | 🔄 IN PROGRESS | ✅ COMPLETE | ⛔ BLOCKED
   6 ⛔ BLOCKED on ONE owner action (Landon merges #24 + ./mvnw verify +
   Railway redeploy) plus REQ-005's history scrub (old DB password still
   reachable at 8afb44c/8a6cf1e — §7.1 filter-repo steps; force-push is
-  owner-approved-only). Frontend doc PR #62.
+  owner-approved-only). Frontend doc PR #62 merged, main @ 60180a4.
+  ------------------------------------------------------------------------------
+  [2026-07-10] AGENT 90: quality sweep done. Contrast MEASURED — ink-3
+  (2.42) upgraded to ink-2 (7.37) across this run's components; light
+  --danger deepened to #b91c1c (4.39→5.89). Coarse-pointer 44px dialog
+  targets added to tokens.css. Secret scan clean; no dangerous sinks;
+  audit = 8 pre-existing baseline vulns only (sonner clean). Bundle
+  growth explained (+33 kB sonner, +42 kB features). REQ-008 flipped.
+  138/138 green. PR #63.
   ------------------------------------------------------------------------------
 
 ================================================================================
@@ -1171,8 +1179,61 @@ APPENDIX A-12 — Backend Verification + Gap PR
       leaked value / rotate it.
   PR # / MAIN COMMIT (this doc update): PR #62.
 --------------------------------------------------------------------------------
-(APPENDIX A blocks for agents 90–94 are filled as those agents complete,
-using the A-90..A-94 field lists from the source master prompt.)
+APPENDIX A-90 — Cross-Cutting Quality Sweep
+  STATUS: ✅ COMPLETE / DATE: 2026-07-10
+  TOKEN SWEEP: all new components consume the tokens.css/Tailwind bridge
+    (text-ink-*, bg-surface-*, border-divider, accent/ok/warn/danger,
+    rounded-sm/pill); arbitrary values limited to the codebase's own
+    established idioms (text-[10px]/[11px] micro-type, z-[60..90]
+    layering). No new magic-color literals (evidence: components reviewed
+    file-by-file; hex appears only in tokens.css + mipsLanguage.ts theme
+    data, the documented exception).
+  A11Y: keyboard walkthroughs in A-11 (trap/Escape/Enter). CONTRAST
+    MEASURED (WCAG relative-luminance script; ratios in output):
+    ink-1 18.09 ✓, ink-2 7.37 ✓, accent 10.45 ✓, ok 7.44 ✓, warn 8.79 ✓,
+    danger-on-surface-2 4.62 ✓ (dark), accent-button 10.96 ✓,
+    danger-button 5.26 ✓. FAILURES FIXED: ink-3 (2.42 dark / 2.56 light)
+    was used for meaningful text in this run's new components → upgraded
+    to ink-2 in AuthModal/SaveSnippetDialog/ShareModal/MySnippetsDrawer/
+    PublicFeed/HistoryPanel/ScreenMagnifier hint; light-theme --danger
+    #dc2626 (4.39 on surface-2, sub-AA) → #b91c1c (5.89 ✓, 6.47 on
+    white). Pre-existing shell-wide ink-3 usage (SettingsDialog, panels)
+    left as-is — pre-dates this run; flagged for the team.
+  RESPONSIVE: 375px modal fit + no h-scroll verified (A-11); touch
+    targets: tokens.css @media (pointer: coarse) rule gives dialog
+    buttons/inputs min-height 44px (fixes the A-11 26.7px finding)
+    while keeping desktop density.
+  STATE SWEEP (REQ-008): every async surface this run added has
+    disabled+label busy states and loading/empty/error UI — verified
+    live: AuthModal 'Signing in…', Save 'Saving…' (double-click cannot
+    double-submit: guarded by `if (busy/saving) return` + disabled),
+    ShareModal 'Updating…', drawer/feed/history loading/empty/error
+    with named HTTP status + Retry (A-09/A-10 live evidence).
+  PERF: bundle 417.64 kB baseline → 492.61 kB (gzip 116.94 → 134.80):
+    +33 kB sonner + ~42 kB feature components — explained, no accidental
+    heavy deps (no html2canvas/lodash; verified package.json diff).
+    Render hygiene: magnifier re-clones only on target change; workspace
+    persistence debounced 250ms; no unthrottled scroll/resize handlers
+    added (grep addEventListener over new files: mousemove/keydown/
+    popstate/beforeunload only, all removed on cleanup). No per-frame
+    allocations added to the run loop (logging fires once at run END).
+  SECURITY: secret scan `git log 4c9d661..HEAD -p` over this run's
+    commits for sk_live/AKIA/private-key/ghp_/password= patterns → no
+    matches. Dangerous sinks: grep dangerouslySetInnerHTML|eval( over
+    src → none (magnifier uses cloneNode/appendChild, not string HTML;
+    innerHTML='' only to clear). npm audit: 8 vulnerabilities — ALL
+    pre-existing at the AGENT 00 baseline (3L/2M/1H/2C, e.g. DOMPurify
+    advisory via transitive deps); sonner (the only dep added this run)
+    is not implicated. Pre-existing set surfaced to the owner rather
+    than blind-bumped at the end of the run.
+  DEAD CODE: none introduced by this run's agents; no orphaned flags.
+  BUILD+TEST: lint 0 / typecheck 0 / build exit 0 / vitest 138/138.
+  REGRESSIONS FIXED: contrast + touch-target findings above.
+  BLOCKED ITEMS: none.
+  PR # / MAIN COMMIT: PR #63.
+--------------------------------------------------------------------------------
+(APPENDIX A blocks for agents 91–94 are filled as those agents complete,
+using the A-91..A-94 field lists from the source master prompt.)
 
 ================================================================================
     APPENDIX B — REQUIREMENTS TRACEABILITY MATRIX (AGENT 01 POPULATES)
@@ -1192,7 +1253,7 @@ the exact owner action. At AGENT 94 exit: zero ⬜, zero 🔄.
   REQ-005 | p.8-9 §2.5; p.38 §7.1; p.56 §10.1 | Backend secrets: env-var indirection, .env.example, .gitignore, rotation, git-history scrub + force-push + re-clone | SECURITY | A12 | ⛔ BLOCKED | — | env indirection/JwtUtil validation/.env untracked DONE upstream; OWNER: old DB password still in history (commits 8afb44c, 8a6cf1e) → run §7.1 filter-repo scrub + force-push + re-clone, and rotate/confirm Railway DB password
   REQ-006 | p.9 §2.6; p.46-48 §8.2 | ScreenMagnifier rewrite: DOM-clone loupe 240x160 @2x, hint state, Escape, no per-mousemove reclone, Monaco excluded | FEATURE | A06 | IMPLEMENTED | #46 | ScreenMagnifier.tsx rewrite; browser-verified clone/hint/Escape
   REQ-007 | p.10 §2.7; p.20 D1 | Toast system via sonner; Toaster at App root; error/success toasts for API calls | UI/UX | A02 | IMPLEMENTED | #42 | src/App.tsx (Toaster mount); A-02
-  REQ-008 | p.10 §2.8 | Loading state on every async button: disabled + spinner/label while in flight; no duplicate submits | UI/UX | A90 | ⬜ | | implemented inline by A07-A10; A90 sweeps
+  REQ-008 | p.10 §2.8 | Loading state on every async button: disabled + spinner/label while in flight; no duplicate submits | UI/UX | A90 | IMPLEMENTED | #63 | busy states shipped inline by A07–A10; sweep evidence in A-90
   REQ-009 | p.10-11 §2.9; p.36 §6.6; p.23 D5 | ?snippet=<id> on boot loads snippet into editor; 404 → toast + default example; document title updated | FEATURE | A08 | IMPLEMENTED | #48 | App.tsx useSnippetDeepLink; live 404-toast + fallback verified (A-08)
   REQ-010 | p.11 §2.10; p.26 D8 | JWT expiry 8h (sprint choice) + README v1.3 note re refresh tokens | FIX | A12 | IMPLEMENTED | up#e2a080f | JwtUtil.java 8h verified; v1.3 note ships in webmars-api#24
   REQ-011 | p.11 §2.11; p.39 §7.2; p.56 §10.1 | CORS: prod + localhost origins, methods, headers, credentials, no wildcards | FIX | A12 | IMPLEMENTED | up#e2a080f | SecurityConfig.java verified; proven live by all browser calls this run

--- a/src/ui/AuthModal.tsx
+++ b/src/ui/AuthModal.tsx
@@ -135,7 +135,7 @@ export function AuthModal() {
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent',
                 mode === m
                   ? 'bg-surface-2 text-ink-1'
-                  : 'text-ink-3 hover:bg-surface-2 hover:text-ink-2',
+                  : 'text-ink-2 hover:bg-surface-2 hover:text-ink-2',
               )}
             >
               {m === 'login' ? 'Sign in' : 'Register'}
@@ -151,7 +151,7 @@ export function AuthModal() {
           }}
         >
           <label className="flex flex-col gap-1">
-            <span className="font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+            <span className="font-mono text-[10px] uppercase text-ink-2" style={{ letterSpacing: '0.06em' }}>
               Username
             </span>
             <input
@@ -167,7 +167,7 @@ export function AuthModal() {
             />
           </label>
           <label className="flex flex-col gap-1">
-            <span className="font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+            <span className="font-mono text-[10px] uppercase text-ink-2" style={{ letterSpacing: '0.06em' }}>
               Password
             </span>
             <input

--- a/src/ui/HistoryPanel.tsx
+++ b/src/ui/HistoryPanel.tsx
@@ -31,7 +31,7 @@ const STATUS_BADGE: Record<api.ExitStatus, string> = {
   COMPLETED: 'bg-ok/15 text-ok',
   ERROR: 'bg-danger/15 text-danger',
   ABORTED: 'bg-warn/15 text-warn',
-  PAUSED: 'bg-surface-3 text-ink-3',
+  PAUSED: 'bg-surface-3 text-ink-2',
 }
 
 function formatWhen(iso: string): string {
@@ -45,10 +45,10 @@ function formatDuration(ms: number | null): string {
 }
 
 function SectionFallback({ state, onRetry }: { state: SectionState<unknown>; onRetry: () => void }) {
-  if (state.kind === 'loading') return <div className="text-[11px] italic text-ink-3">Loading…</div>
+  if (state.kind === 'loading') return <div className="text-[11px] italic text-ink-2">Loading…</div>
   if (state.kind === 'error') {
     return (
-      <div className="rounded-md border border-divider bg-surface-2 p-2 text-[11px] text-ink-3">
+      <div className="rounded-md border border-divider bg-surface-2 p-2 text-[11px] text-ink-2">
         <div className="text-danger">{state.message}</div>
         <button
           type="button"
@@ -60,7 +60,7 @@ function SectionFallback({ state, onRetry }: { state: SectionState<unknown>; onR
       </div>
     )
   }
-  return <div className="text-[11px] italic text-ink-3">No runs yet.</div>
+  return <div className="text-[11px] italic text-ink-2">No runs yet.</div>
 }
 
 export function HistoryPanel() {
@@ -120,7 +120,7 @@ export function HistoryPanel() {
 
   if (!authToken) {
     return (
-      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-2">
         <span>Sign in to record and see your run history. </span>
         <button
           type="button"
@@ -134,7 +134,7 @@ export function HistoryPanel() {
   }
 
   if (recent.kind === 'loading' && mostRun.kind === 'loading') {
-    return <div className="p-3 text-xs italic text-ink-3">Loading run history…</div>
+    return <div className="p-3 text-xs italic text-ink-2">Loading run history…</div>
   }
 
   if (
@@ -144,7 +144,7 @@ export function HistoryPanel() {
     mostRun.items.length === 0
   ) {
     return (
-      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-2">
         Run a saved snippet to see your history here.
       </div>
     )
@@ -153,7 +153,7 @@ export function HistoryPanel() {
   return (
     <div className="flex flex-col gap-3">
       <section>
-        <h4 className="mb-1.5 font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+        <h4 className="mb-1.5 font-mono text-[10px] uppercase text-ink-2" style={{ letterSpacing: '0.06em' }}>
           Recent Runs
         </h4>
         {recent.kind !== 'ready' || recent.items.length === 0 ? (
@@ -181,7 +181,7 @@ export function HistoryPanel() {
                     {run.exitStatus.toLowerCase()}
                   </span>
                 </div>
-                <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-ink-3">
+                <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-ink-2">
                   <span>{formatWhen(run.startedAt)}</span>
                   <span className="flex-1" />
                   <span>{formatDuration(run.durationMs)}</span>
@@ -193,7 +193,7 @@ export function HistoryPanel() {
       </section>
 
       <section>
-        <h4 className="mb-1.5 font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+        <h4 className="mb-1.5 font-mono text-[10px] uppercase text-ink-2" style={{ letterSpacing: '0.06em' }}>
           Most Run
         </h4>
         {mostRun.kind !== 'ready' || mostRun.items.length === 0 ? (
@@ -215,7 +215,7 @@ export function HistoryPanel() {
                     ×{entry.runCount}
                   </span>
                 </div>
-                <div className="mt-0.5 font-mono text-[10px] text-ink-3">
+                <div className="mt-0.5 font-mono text-[10px] text-ink-2">
                   last run {formatWhen(entry.lastRun)}
                 </div>
               </li>

--- a/src/ui/MySnippetsDrawer.tsx
+++ b/src/ui/MySnippetsDrawer.tsx
@@ -118,7 +118,7 @@ export function MySnippetsDrawer() {
 
   if (!authToken) {
     return (
-      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-2">
         <span>Sign in to save snippets to your account. </span>
         <button
           type="button"
@@ -132,12 +132,12 @@ export function MySnippetsDrawer() {
   }
 
   if (state.kind === 'loading' || state.kind === 'idle') {
-    return <div className="p-3 text-xs italic text-ink-3">Loading your snippets…</div>
+    return <div className="p-3 text-xs italic text-ink-2">Loading your snippets…</div>
   }
 
   if (state.kind === 'error') {
     return (
-      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-2">
         <div className="text-danger">{state.message}</div>
         <button
           type="button"
@@ -161,7 +161,7 @@ export function MySnippetsDrawer() {
       </button>
 
       {state.snippets.length === 0 ? (
-        <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+        <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-2">
           <div>Save your first snippet to see it here.</div>
           <button
             type="button"
@@ -215,7 +215,7 @@ export function MySnippetsDrawer() {
                 <span
                   className={cn(
                     'flex-none rounded-pill px-1.5 py-0.5 font-mono text-[9px] uppercase',
-                    snippet.visibility === 'PUBLIC' ? 'bg-ok/15 text-ok' : 'bg-surface-3 text-ink-3',
+                    snippet.visibility === 'PUBLIC' ? 'bg-ok/15 text-ok' : 'bg-surface-3 text-ink-2',
                   )}
                   style={{ letterSpacing: '0.05em' }}
                 >
@@ -223,7 +223,7 @@ export function MySnippetsDrawer() {
                 </span>
               </div>
               <div className="mt-0.5 flex items-center gap-2">
-                <span className="font-mono text-[10px] text-ink-3">{formatWhen(snippet.updatedAt)}</span>
+                <span className="font-mono text-[10px] text-ink-2">{formatWhen(snippet.updatedAt)}</span>
                 <span className="flex-1" />
                 <button
                   type="button"
@@ -231,14 +231,14 @@ export function MySnippetsDrawer() {
                     setEditingId(snippet.id)
                     setEditingTitle(snippet.title ?? '')
                   }}
-                  className="text-[10px] text-ink-3 hover:text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  className="text-[10px] text-ink-2 hover:text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 >
                   Rename
                 </button>
                 <button
                   type="button"
                   onClick={() => setPendingDelete(snippet)}
-                  className="text-[10px] text-ink-3 hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  className="text-[10px] text-ink-2 hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 >
                   Delete
                 </button>

--- a/src/ui/PublicFeed.tsx
+++ b/src/ui/PublicFeed.tsx
@@ -66,12 +66,12 @@ export function PublicFeed() {
   }
 
   if (state.kind === 'loading') {
-    return <div className="p-3 text-xs italic text-ink-3">Loading public snippets…</div>
+    return <div className="p-3 text-xs italic text-ink-2">Loading public snippets…</div>
   }
 
   if (state.kind === 'error') {
     return (
-      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+      <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-2">
         <div className="text-danger">{state.message}</div>
         <button
           type="button"
@@ -89,7 +89,7 @@ export function PublicFeed() {
   return (
     <div className="flex flex-col gap-2">
       {page.content.length === 0 ? (
-        <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-3">
+        <div className="rounded-md border border-divider bg-surface-2 p-3 text-xs text-ink-2">
           No public snippets yet. Be the first.
         </div>
       ) : (
@@ -104,7 +104,7 @@ export function PublicFeed() {
               >
                 {snippet.title ?? `snippet-${snippet.id}`}
               </button>
-              <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-ink-3">
+              <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-ink-2">
                 <span>{snippet.owner?.username ?? 'unknown'}</span>
                 <span className="flex-1" />
                 <span>{formatWhen(snippet.updatedAt)}</span>
@@ -124,7 +124,7 @@ export function PublicFeed() {
           >
             ← Previous
           </button>
-          <span className="font-mono text-[10px] text-ink-3">
+          <span className="font-mono text-[10px] text-ink-2">
             Page {page.number + 1} of {page.totalPages}
           </span>
           <button

--- a/src/ui/SaveSnippetDialog.tsx
+++ b/src/ui/SaveSnippetDialog.tsx
@@ -117,7 +117,7 @@ function SaveSnippetForm() {
           }}
         >
           <label className="flex flex-col gap-1">
-            <span className="font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+            <span className="font-mono text-[10px] uppercase text-ink-2" style={{ letterSpacing: '0.06em' }}>
               Title
             </span>
             <input
@@ -132,7 +132,7 @@ function SaveSnippetForm() {
           </label>
 
           <fieldset className="flex flex-col gap-1">
-            <legend className="mb-1 font-mono text-[10px] uppercase text-ink-3" style={{ letterSpacing: '0.06em' }}>
+            <legend className="mb-1 font-mono text-[10px] uppercase text-ink-2" style={{ letterSpacing: '0.06em' }}>
               Visibility
             </legend>
             {(
@@ -159,7 +159,7 @@ function SaveSnippetForm() {
                 />
                 <span className="flex-1">
                   <span className="block text-xs text-ink-1">{option.label}</span>
-                  <span className="mt-0.5 block text-[11px] text-ink-3">{option.sub}</span>
+                  <span className="mt-0.5 block text-[11px] text-ink-2">{option.sub}</span>
                 </span>
               </label>
             ))}

--- a/src/ui/ShareModal.tsx
+++ b/src/ui/ShareModal.tsx
@@ -133,7 +133,7 @@ export function ShareModal() {
                   {visibility === 'PUBLIC' ? 'Public' : 'Private'}
                 </span>
               </div>
-              <div className="mt-0.5 text-[11px] text-ink-3">
+              <div className="mt-0.5 text-[11px] text-ink-2">
                 {visibility === 'PUBLIC'
                   ? 'Anyone with the link can open it.'
                   : 'Only you can open it — the link 404s for everyone else.'}

--- a/src/ui/tokens.css
+++ b/src/ui/tokens.css
@@ -66,7 +66,9 @@
 
   --accent: #0891b2;
   --warn:   #d97706;
-  --danger: #dc2626;
+  /* #b91c1c (not #dc2626): measured 4.39:1 on --surface-2 at #dc2626 —
+     just under the WCAG AA 4.5:1 floor for small error text. */
+  --danger: #b91c1c;
   --ok:     #059669;
 
   --shadow-press: inset 0 1px 2px rgba(0, 0, 0, 0.08);
@@ -92,6 +94,18 @@
   --warn:   #ffd700;
   --danger: #ff5555;
   --ok:     #00ff7f;
+}
+
+/* ─ touch ergonomics ─────────────────────────────────────────────────
+   On touch-primary devices, dialog buttons and inputs meet the 44px
+   minimum target size (WCAG 2.5.8 / Enhancement Plan C8). Pointer-fine
+   desktops keep the IDE's compact density. */
+@media (pointer: coarse) {
+  [role='dialog'] button,
+  [role='alertdialog'] button,
+  [role='dialog'] input {
+    min-height: 44px;
+  }
 }
 
 /* ─ animations ─────────────────────────────────────────────────────── */

--- a/src/ui/tools/ScreenMagnifier.tsx
+++ b/src/ui/tools/ScreenMagnifier.tsx
@@ -112,7 +112,7 @@ export function ScreenMagnifier() {
         }}
       />
       {!target && (
-        <div className="flex h-full w-full items-center justify-center px-3 text-center text-[11px] text-ink-3">
+        <div className="flex h-full w-full items-center justify-center px-3 text-center text-[11px] text-ink-2">
           Hover a panel to magnify
         </div>
       )}


### PR DESCRIPTION
## Agent
AGENT 90 - Cross-Cutting Quality Sweep (loop position: 14 of 18)

## What changed and why
Contrast was MEASURED, not eyeballed: ink-3 lands at 2.42:1 on the dark surfaces - far under WCAG AA - so every meaningful use in this run's new components moves to ink-2 (7.37:1); light-theme --danger deepens from #dc2626 (4.39:1, sub-AA on surface-2) to #b91c1c (5.89:1). A pointer:coarse rule in tokens.css gives dialog buttons/inputs 44px touch targets without loosening desktop density.

## Evidence summary
- Contrast ratios measured with a WCAG relative-luminance script (full table in Appendix A-90)
- Secret scan of this run's commits: clean; no dangerouslySetInnerHTML/eval in src
- npm audit: 8 vulnerabilities, all pre-existing at baseline; sonner (only dep added) clean
- Bundle 417.64 -> 492.61 kB, fully explained (+sonner +feature components)
- lint/typecheck/build exit 0; tests 138/138

## Out of scope / follow-ups
Pre-existing shell-wide ink-3 usage and the 8 baseline npm audit findings are flagged for the team, not churned at the end of the run.